### PR TITLE
Fix continuous integration failures with the PARVMEC tests.

### DIFF
--- a/Testing/test_utilities/wout_diff.cpp
+++ b/Testing/test_utilities/wout_diff.cpp
@@ -123,6 +123,7 @@ int main(int argc, const char * argv[]) {
     if (!pass) {
         std::cout << "Quantity " << quantity
                   << " has unequal lengths." << std::endl;
+        std::cout << q1.size() << " " << q2.size() << std::endl;
         exit(1);
     }
 

--- a/Testing/test_utilities/wout_diff.cpp
+++ b/Testing/test_utilities/wout_diff.cpp
@@ -70,6 +70,7 @@ std::vector<double> wout_quantity(const std::string wout_file,
 
         total_length *= dim_length;
     }
+    total_length = std::max(total_length, static_cast<size_t> (1));
 
     std::vector<double> buffer(total_length);
     nc_get_var(ncid, varid, buffer.data());

--- a/Testing/test_utilities/wout_diff.cpp
+++ b/Testing/test_utilities/wout_diff.cpp
@@ -63,14 +63,13 @@ std::vector<double> wout_quantity(const std::string wout_file,
     std::vector<int> dimids(ndims);
     nc_inq_vardimid(ncid, varid, dimids.data());
 
-    size_t total_length = 0;
+    size_t total_length = 1;
     for (int dimid: dimids) {
         size_t dim_length;
         nc_inq_dimlen(ncid, dimid, &dim_length);
 
-        total_length += dim_length;
+        total_length *= dim_length;
     }
-    total_length = std::max(total_length, static_cast<size_t> (1));
 
     std::vector<double> buffer(total_length);
     nc_get_var(ncid, varid, buffer.data());

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (NAME    vmec_free_boundary_check_bmnc_test
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=7.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=9.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=7.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=8.0E-14)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test (NAME    vmec_free_boundary_check_betatotal_test
 add_test (NAME    vmec_free_boundary_check_betaxis_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=betaxis -tol=7.0E-17)
 add_test (NAME    vmec_free_boundary_check_bmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=8.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test (NAME    vmec_free_boundary_check_betatotal_test
 add_test (NAME    vmec_free_boundary_check_betaxis_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=betaxis -tol=7.0E-17)
 add_test (NAME    vmec_free_boundary_check_bmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=5.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=8.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -57,7 +57,7 @@ add_test (NAME    vmec_free_boundary_check_chi_test
 add_test (NAME    vmec_free_boundary_check_chipf_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=chipf -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_currumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=6.0E-7)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=8.0E-7)
 add_test (NAME    vmec_free_boundary_check_currvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currvmnc -tol=2.0E-7)
 add_test (NAME    vmec_free_boundary_check_DCurr_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -135,4 +135,4 @@ add_test (NAME    vmec_free_boundary_check_xn_test
 add_test (NAME    vmec_free_boundary_check_xn_nyq_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=xn_nyq -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_zmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=1.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=2.0E-14)

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=8.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=9.0E-14)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -111,7 +111,7 @@ add_test (NAME    vmec_free_boundary_check_rbtor_test
 add_test (NAME    vmec_free_boundary_check_rbtor0_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=rbtor0 -tol=4.0E-15)
 add_test (NAME    vmec_free_boundary_check_rmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=rmnc -tol=7.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=rmnc -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_specw_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=specw -tol=2.0E-12)
 add_test (NAME    vmec_free_boundary_check_volabgB_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test (NAME    vmec_free_boundary_check_bsubsmns_test
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=9.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=1.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -135,4 +135,4 @@ add_test (NAME    vmec_free_boundary_check_xn_test
 add_test (NAME    vmec_free_boundary_check_xn_nyq_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=xn_nyq -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_zmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=4.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=5.0E-14)

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -135,4 +135,4 @@ add_test (NAME    vmec_free_boundary_check_xn_test
 add_test (NAME    vmec_free_boundary_check_xn_nyq_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=xn_nyq -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_zmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=8.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=1.0E-14)

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=4.0E-14)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -39,7 +39,7 @@ add_test (NAME    vmec_free_boundary_check_betaxis_test
 add_test (NAME    vmec_free_boundary_check_bmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=5.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -39,7 +39,7 @@ add_test (NAME    vmec_free_boundary_check_betaxis_test
 add_test (NAME    vmec_free_boundary_check_bmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=5.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=3.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=4.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -57,7 +57,7 @@ add_test (NAME    vmec_free_boundary_check_chi_test
 add_test (NAME    vmec_free_boundary_check_chipf_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=chipf -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_currumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=8.0E-7)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=9.0E-7)
 add_test (NAME    vmec_free_boundary_check_currvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currvmnc -tol=2.0E-7)
 add_test (NAME    vmec_free_boundary_check_DCurr_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test (NAME    vmec_free_boundary_check_bsubsmns_test
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (NAME    vmec_free_boundary_check_bmnc_test
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=9.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -39,7 +39,7 @@ add_test (NAME    vmec_free_boundary_check_betaxis_test
 add_test (NAME    vmec_free_boundary_check_bmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=5.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=4.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -79,7 +79,7 @@ add_test (NAME    vmec_free_boundary_check_fsqt_test
 add_test (NAME    vmec_free_boundary_check_fsqz_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=fsqz -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_gmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=gmnc -tol=9.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=gmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_IonLarmor_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=IonLarmor -tol=8.0E-17)
 add_test (NAME    vmec_free_boundary_check_iotaf_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -57,7 +57,7 @@ add_test (NAME    vmec_free_boundary_check_chi_test
 add_test (NAME    vmec_free_boundary_check_chipf_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=chipf -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_currumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=3.0E-7)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=4.0E-7)
 add_test (NAME    vmec_free_boundary_check_currvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currvmnc -tol=2.0E-7)
 add_test (NAME    vmec_free_boundary_check_DCurr_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -79,7 +79,7 @@ add_test (NAME    vmec_free_boundary_check_fsqt_test
 add_test (NAME    vmec_free_boundary_check_fsqz_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=fsqz -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_gmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=gmnc -tol=6.0E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=gmnc -tol=9.0E-15)
 add_test (NAME    vmec_free_boundary_check_IonLarmor_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=IonLarmor -tol=8.0E-17)
 add_test (NAME    vmec_free_boundary_check_iotaf_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (NAME    vmec_free_boundary_check_bmnc_test
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (NAME    vmec_free_boundary_check_bmnc_test
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=5.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test (NAME    vmec_free_boundary_check_bsubsmns_test
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=1.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test (NAME    vmec_free_boundary_check_bsubsmns_test
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=8.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=9.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test (NAME    vmec_free_boundary_check_bsubsmns_test
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=3.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=2.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=8.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=4.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=7.0E-14)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=9.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=1.0E-13)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test (NAME    vmec_free_boundary_check_betatotal_test
 add_test (NAME    vmec_free_boundary_check_betaxis_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=betaxis -tol=7.0E-17)
 add_test (NAME    vmec_free_boundary_check_bmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=4.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -135,4 +135,4 @@ add_test (NAME    vmec_free_boundary_check_xn_test
 add_test (NAME    vmec_free_boundary_check_xn_nyq_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=xn_nyq -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_zmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=zmns -tol=4.0E-14)

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupumnc -tol=4.0E-12)
 add_test (NAME    vmec_free_boundary_check_bsupvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=3.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsupvmnc -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_buco_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=3.0E-17)
 add_test (NAME    vmec_free_boundary_check_bvco_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -57,7 +57,7 @@ add_test (NAME    vmec_free_boundary_check_chi_test
 add_test (NAME    vmec_free_boundary_check_chipf_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=chipf -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_currumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=4.0E-7)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=6.0E-7)
 add_test (NAME    vmec_free_boundary_check_currvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currvmnc -tol=2.0E-7)
 add_test (NAME    vmec_free_boundary_check_DCurr_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test (NAME    vmec_free_boundary_check_betatotal_test
 add_test (NAME    vmec_free_boundary_check_betaxis_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=betaxis -tol=7.0E-17)
 add_test (NAME    vmec_free_boundary_check_bmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test (NAME    vmec_free_boundary_check_betatotal_test
 add_test (NAME    vmec_free_boundary_check_betaxis_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=betaxis -tol=7.0E-17)
 add_test (NAME    vmec_free_boundary_check_bmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=3.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bmnc -tol=4.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test (NAME    vmec_free_boundary_check_bmnc_test
 add_test (NAME    vmec_free_boundary_check_bsubsmns_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubsmns -tol=2.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=5.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubumnc -tol=7.0E-15)
 add_test (NAME    vmec_free_boundary_check_bsubvmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=bsubvmnc -tol=3.0E-14)
 add_test (NAME    vmec_free_boundary_check_bsupumnc_test


### PR DESCRIPTION
There was a bug in the diff_wout utility where the array sizes where computed wrong. Adjust test tolerance after checking the entire array.