### PR TITLE
Fix tests for volavgB

### DIFF
--- a/Testing/test_utilities/wout_diff.cpp
+++ b/Testing/test_utilities/wout_diff.cpp
@@ -70,7 +70,6 @@ std::vector<double> wout_quantity(const std::string wout_file,
 
         total_length *= dim_length;
     }
-    total_length = std::max(total_length, static_cast<size_t> (1));
 
     std::vector<double> buffer(total_length);
     nc_get_var(ncid, varid, buffer.data());

--- a/Testing/tests/fixed_boundary_test/CMakeLists.txt
+++ b/Testing/tests/fixed_boundary_test/CMakeLists.txt
@@ -109,8 +109,8 @@ add_test (NAME    vmec_fixed_boundary_check_rmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=rmnc -tol=1.0E-20)
 add_test (NAME    vmec_fixed_boundary_check_specw_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=specw -tol=1.0E-20)
-add_test (NAME    vmec_fixed_boundary_check_volabgB_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volabgB -tol=1.0E-20)
+add_test (NAME    vmec_fixed_boundary_check_volavgB_test
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volavgB -tol=1.0E-20)
 add_test (NAME    vmec_fixed_boundary_check_volume_p_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volume_p -tol=1.0E-20)
 add_test (NAME    vmec_fixed_boundary_check_vp_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -114,8 +114,8 @@ add_test (NAME    vmec_free_boundary_check_rmnc_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=rmnc -tol=5.0E-14)
 add_test (NAME    vmec_free_boundary_check_specw_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=specw -tol=2.0E-12)
-add_test (NAME    vmec_free_boundary_check_volabgB_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volabgB -tol=1.0E-20)
+add_test (NAME    vmec_free_boundary_check_volavgB_test
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volavgB -tol=1.0E-20)
 add_test (NAME    vmec_free_boundary_check_volume_p_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volume_p -tol=9.0E-15)
 add_test (NAME    vmec_free_boundary_check_vp_test

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -115,7 +115,7 @@ add_test (NAME    vmec_free_boundary_check_rmnc_test
 add_test (NAME    vmec_free_boundary_check_specw_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=specw -tol=2.0E-12)
 add_test (NAME    vmec_free_boundary_check_volavgB_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volavgB -tol=1.0E-20)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volavgB -tol=8.0E-15)
 add_test (NAME    vmec_free_boundary_check_volume_p_test
           COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=volume_p -tol=9.0E-15)
 add_test (NAME    vmec_free_boundary_check_vp_test


### PR DESCRIPTION
Test checking for `volavgB` was mistakenly checking for `volabgB` which did not exist. Remove the check in the test utility that could mask bugs like this in the future.