### PR TITLE
added mnyq and nnyq to wout file

### DIFF
--- a/Sources/General/add_fluxes.f90
+++ b/Sources/General/add_fluxes.f90
@@ -37,8 +37,8 @@
         top = icurv(js)
         bot = 0
         DO j=1,nznt
-          top = top - pwint(j,js)*(pguu(j,js)*bsupu(j,js) &
-            + pguv(j,js)*bsupv(j,js))
+          top = top - pwint(j,js)*(  pguu(j,js)*bsupu(j,js) &
+                                   + pguv(j,js)*bsupv(j,js))
           bot = bot + pwint(j,js)*overg(j,js)*pguu(j,js)
         END DO
         IF (bot.ne.zero) chips(js) = top/bot

--- a/Sources/Input_Output/readin.f
+++ b/Sources/Input_Output/readin.f
@@ -43,10 +43,10 @@ C-----------------------------------------------
 !       STACKING ORDER DEPENDS ON LASYM AND LTHREED. EACH COMPONENT XCC, XSS, XSC, XCS
 !       HAS SIZE = mns. (PHIFAC, MSE TAKE UP 1 INDEX EACH AT END OF ARRAY)
 !
-!         LTHREED=F,      LTHREED=F,      LTHREED=T,      LTHREED=T 
+!         LTHREED=F,      LTHREED=F,      LTHREED=T,      LTHREED=T
 !         LASYM=F         LASYM=T         LASYM=F         LASYM=T
 !
-!          rmncc           rmncc           rmncc           rmncc           
+!          rmncc           rmncc           rmncc           rmncc
 !          zmnsc           rmnsc           rmnss           rmnss
 !          lmnsc           zmnsc           zmnsc           rmnsc
 !                          zmncc           zmncs           rmncs
@@ -69,7 +69,7 @@ C-----------------------------------------------
 !                in MKS units [NWT/M**2]
 !                Interpretation changes with pmass_type
 !          ac:   expansion coefficients for the normalized (pcurr(s=1) = 1)
-!                radial derivative of the flux-averaged toroidal current density 
+!                radial derivative of the flux-averaged toroidal current density
 !                (power series in s) used when ncurr=1
 !                Interpretation changes with pcurr_type
 !    ai_aux_s:   Auxiliary array for iota profile. Used for splines, s values
@@ -109,7 +109,7 @@ C-----------------------------------------------
 !   Convergence control parameters
 !  ftol_array:   array of value of residual(s) at which each multigrid
 !                iteration ends
-! niter_array:   array of number of iterations (used to terminate run) at 
+! niter_array:   array of number of iterations (used to terminate run) at
 !                each multigrid iteration
 !       nstep:   number of timesteps between printouts on screen
 !    nvacskip:   iterations skipped between full update of vacuum solution
@@ -127,7 +127,7 @@ C-----------------------------------------------
 !  mgrid_file:   full path for vacuum Green''s function data
 !  pcurr_type:   Specifies parameterization type of pcurr function
 !                  'power_series' - I'(s)=Sum[ ac(j) s ** j] - Default
-!                  'gauss_trunc'  - I'(s)=ac(0) (exp(-(s/ac(1)) ** 2) - 
+!                  'gauss_trunc'  - I'(s)=ac(0) (exp(-(s/ac(1)) ** 2) -
 !                                                exp(-(1/ac(1)) ** 2))
 !                   others - see function pcurr
 !  piota_type:   Specifies parameterization type of piota function
@@ -135,7 +135,7 @@ C-----------------------------------------------
 !                   others - see function piota
 !  pmass_type:   Specifies parameterization type of pmass function
 !                  'power_series' - p(s)=Sum[ am(j) s ** j] - Default
-!                  'gauss_trunc'  - p(s)=am(0) (exp(-(s/am(1)) ** 2) - 
+!                  'gauss_trunc'  - p(s)=am(0) (exp(-(s/am(1)) ** 2) -
 !                                                exp(-(1/am(1)) ** 2))
 !                   others - see function pmass
 
@@ -269,7 +269,7 @@ C-----------------------------------------------
 
 !
 !     READ IN COMMENTS DEMARKED BY "!"
-!  
+!
       REWIND (iunit, iostat=iexit)
       IF (lWrite) THEN
          DO WHILE(iexit .EQ. 0)
@@ -289,16 +289,16 @@ C-----------------------------------------------
 !
       IF (lfreeb) THEN
          CALL second0(trc)
-         CALL read_mgrid (mgrid_file, extcur, nzeta, nfp, 
+         CALL read_mgrid (mgrid_file, extcur, nzeta, nfp,
      &                    lscreen, ier_flag, comm = RUNVMEC_COMM_WORLD)
          CALL second0(tzc)
          mgrid_file_read_time = mgrid_file_read_time + (tzc - trc)
 
          IF (lfreeb .AND. lscreen .AND. lwrite) THEN
-            WRITE (6,'(2x,a,1p,e10.2,a)') 'Time to read MGRID file: ', 
+            WRITE (6,'(2x,a,1p,e10.2,a)') 'Time to read MGRID file: ',
      &             tzc - trc, ' s'
             IF (ier_flag .ne. norm_term_flag) RETURN
-            IF (lwrite) WRITE (nthreed,20) nr0b, nz0b, np0b, rminb, 
+            IF (lwrite) WRITE (nthreed,20) nr0b, nz0b, np0b, rminb,
      &                         rmaxb, zminb, zmaxb, TRIM(mgrid_file)
  20         FORMAT(//,' VACUUM FIELD PARAMETERS:',/,1x,24('-'),/,
      &     '  nr-grid  nz-grid  np-grid      rmin      rmax      zmin',
@@ -455,7 +455,7 @@ C-----------------------------------------------
             ELSE
                WRITE (nthreed,140)
             END IF
-!  Print out ai array          
+!  Print out ai array
 !          WRITE(nthreed,135)(ai(i-1),i=1, SIZE(ai))
             WRITE(nthreed,143) TRIM(piota_type)
             SELECT CASE(TRIM(piota_type))
@@ -599,10 +599,10 @@ C-----------------------------------------------
 
       DO m=0, mpol1
          mj = m + joff
-         IF (lfreeb .and. 
+         IF (lfreeb .and.
      &       (mfilter_fbdy.gt.1 .and. m.gt.mfilter_fbdy)) CYCLE
          DO n = -ntor, ntor
-            IF (lfreeb .and. 
+            IF (lfreeb .and.
      &         (nfilter_fbdy.gt.0 .and. ABS(n).gt.nfilter_fbdy)) CYCLE
             ni = ABS(n) + ioff
             IF (n .eq. 0) THEN
@@ -662,7 +662,7 @@ C-----------------------------------------------
 !
 !     CONVERT TO INTERNAL FORM FOR (CONSTRAINED) m=1 MODES
 !     INTERNALLY, FOR m=1: XC(rss) = .5(RSS+ZCS), XC(zcs) = .5(RSS-ZCS)
-!     WITH XC(zcs) -> 0 FOR POLAR CONSTRAINT 
+!     WITH XC(zcs) -> 0 FOR POLAR CONSTRAINT
 !     (see convert_sym, convert_asym in totzsp_mod file)
 !
 
@@ -682,7 +682,7 @@ C-----------------------------------------------
          END IF
          IF (ALLOCATED(temp)) DEALLOCATE (temp)
       END IF
-      
+
 !
 !     PARSE TYPE OF PRECONDITIONER
 !
@@ -693,22 +693,22 @@ C-----------------------------------------------
 
 !     ALL THE FOLLOWING USE THE FULL 2D BLOCK-TRI PRECONDITIONER
 !     BUT DIFFER IN THE WAY TIME-EVOLUTION IS HANDLED
-      SELECT CASE (ch1) 
+      SELECT CASE (ch1)
          CASE ('c', 'C')
 !conjugate gradient
-            IF (ch2 == 'g' .or. ch2 == 'G') itype_precon = 1
+            IF (ch2 == 'g' .or. ch2 == 'G') itype_precon = 1  ! 'cg'
             LPRECOND = .TRUE.
          CASE ('g', 'G')
 !gmres or gmresr
-            IF (ch2 == 'm' .or. ch2 == 'M') itype_precon = 2
-            IF (LEN_TRIM(precon_type) == 6) itype_precon = 3
+            IF (ch2 == 'm' .or. ch2 == 'M') itype_precon = 2 ! 'gm'
+            IF (LEN_TRIM(precon_type) == 6) itype_precon = 3 ! 'gmresr'
             LPRECOND = .TRUE.
          CASE ('t', 'T')
 !transpose free qmr
-            IF (ch2 == 'f' .or. ch2 == 'F') itype_precon = 4
+            IF (ch2 == 'f' .or. ch2 == 'F') itype_precon = 4 ! 'tf'
             LPRECOND = .TRUE.
       END SELECT
-      
+
 
       iresidue = -1
 

--- a/Sources/Input_Output/wrout.f
+++ b/Sources/Input_Output/wrout.f
@@ -1,4 +1,4 @@
-      SUBROUTINE wrout(bsq, gsqrt, bsubu, bsubv, bsubs, bsupv, bsupu, 
+      SUBROUTINE wrout(bsq, gsqrt, bsubu, bsubv, bsubs, bsupv, bsupu,
      1                 rzl_array, gc_array, ier_flag, lwrite
 #ifdef _ANIMEC
      2                ,tau_an, sigma_an, ppar, pperp, onembc, pbprim,
@@ -18,7 +18,7 @@
       USE vmec_io
       USE realspace, ONLY: phip, chip, gsqrta=>z1, z1=>z1
       USE totzsp_mod
-      USE vforces, ONLY: bsupua=>brmn_e, bsupva=>czmn_o, bsqa=>bzmn_e, 
+      USE vforces, ONLY: bsupua=>brmn_e, bsupva=>czmn_o, bsqa=>bzmn_e,
      1                   bsubsa=>armn_e, bsubua=>azmn_e, bsubva=>armn_o
 #ifdef _VACUUM2
       USE vac2_vacmod, ONLY: potvac, mnpd, xmpot, xnpot
@@ -29,7 +29,7 @@
       USE angle_constraints, ONLY: getrz
 #endif
 !undef NETCDF IF TXT DESIRED
-#ifdef NETCDF      
+#ifdef NETCDF
       USE ezcdf
       USE read_wout_mod, ONLY: Compute_Currents,
      &  vn_version, vn_extension, vn_mgrid,
@@ -55,7 +55,7 @@
      &  vn_gmnc, vn_bmnc, vn_bsubumnc, vn_bsubvmnc, vn_bsubsmns,
      &  vn_bsupumnc, vn_bsupvmnc, vn_rmns, vn_zmnc, vn_lmnc, vn_gmns,
      &  vn_bmns, vn_bsubumns, vn_bsubvmns, vn_bsubsmnc, vn_bsupumns,
-     &  vn_bsupvmns, vn_rbc, vn_zbs, vn_rbs, vn_zbc,
+     &  vn_bsupvmns, vn_rbc, vn_zbs, vn_rbs, vn_zbc, vn_mnyq, vn_nnyq,
      &  ln_version, ln_extension, ln_mgrid,
 
      &  vn_bsubumnc_sur, vn_bsubvmnc_sur,                      !MRC 10-15-15
@@ -67,24 +67,24 @@
      1  ln_magen, ln_therm, ln_gam, ln_maxr, ln_minr, ln_maxz, ln_fp,
      2  ln_radnod, ln_polmod, ln_tormod, ln_maxmod, ln_maxit, ln_actit,
      2  ln_maxpot, ln_potsin, ln_potcos,
-     3  ln_asym, ln_recon, ln_free, ln_error, ln_aspect, ln_beta, 
+     3  ln_asym, ln_recon, ln_free, ln_error, ln_aspect, ln_beta,
      4  ln_pbeta, ln_tbeta, ln_abeta, ln_b0, ln_rbt0, ln_maxmod_nyq,
-     5  ln_rbt1, ln_sgs, ln_lar, ln_modB, ln_ctor, ln_amin, ln_Rmaj, 
+     5  ln_rbt1, ln_sgs, ln_lar, ln_modB, ln_ctor, ln_amin, ln_Rmaj,
      6  ln_mse, ln_thom, ln_flp, ln_nobd, ln_nbset, ln_next, ln_nbfld,
-     7  ln_pmod, ln_tmod, ln_pmod_nyq, ln_tmod_nyq, ln_racc, ln_zacs, 
+     7  ln_pmod, ln_tmod, ln_pmod_nyq, ln_tmod_nyq, ln_racc, ln_zacs,
      7  ln_racs, ln_zacc, ln_iotaf, ln_qfact, ln_am, ln_ac, ln_ai,
      7  ln_pmass_type, ln_pcurr_type, ln_piota_type,
-     7  ln_am_aux_s, ln_am_aux_f, ln_ac_aux_s, ln_ac_aux_f, 
-     7  ln_ai_aux_s, ln_ai_aux_f, ln_chi, ln_chipf, 
+     7  ln_am_aux_s, ln_am_aux_f, ln_ac_aux_s, ln_ac_aux_f,
+     7  ln_ai_aux_s, ln_ai_aux_f, ln_chi, ln_chipf,
      8  ln_presf, ln_phi, ln_phipf, ln_jcuru, ln_jcurv, ln_iotah,
-     9  ln_mass, ln_presh, ln_betah, ln_buco, ln_bvco, ln_vp, ln_specw, 
-     A  ln_vol, ln_phip, ln_jdotb, ln_bdotb, ln_bgrv, ln_merc, 
-     B  ln_mshear, ln_mwell, ln_mcurr, ln_mgeo, ln_equif, ln_fsq, 
-     C  ln_wdot, ln_extcur, ln_curlab, ln_rmnc, ln_zmns, ln_lmns, 
-     D  ln_gmnc, ln_bmnc, ln_bsubumnc, ln_bsubvmnc, ln_bsubsmns, 
+     9  ln_mass, ln_presh, ln_betah, ln_buco, ln_bvco, ln_vp, ln_specw,
+     A  ln_vol, ln_phip, ln_jdotb, ln_bdotb, ln_bgrv, ln_merc,
+     B  ln_mshear, ln_mwell, ln_mcurr, ln_mgeo, ln_equif, ln_fsq,
+     C  ln_wdot, ln_extcur, ln_curlab, ln_rmnc, ln_zmns, ln_lmns,
+     D  ln_gmnc, ln_bmnc, ln_bsubumnc, ln_bsubvmnc, ln_bsubsmns,
      E  ln_bsupumnc, ln_bsupvmnc, ln_rmns, ln_zmnc, ln_lmnc, ln_gmns,
-     F  ln_bmns, ln_bsubumns, ln_bsubvmns, ln_bsubsmnc, ln_bsupumns, 
-     G  ln_bsupvmns, ln_rbc, ln_zbs, ln_rbs, ln_zbc,
+     F  ln_bmns, ln_bsubumns, ln_bsubvmns, ln_bsubsmnc, ln_bsupumns,
+     G  ln_bsupvmns, ln_rbc, ln_zbs, ln_rbs, ln_zbc, ln_mnyq, ln_nnyq,
 
      &  ln_bsubumnc_sur, ln_bsubvmnc_sur,          !MRC 10-15-15
      &  ln_bsupumnc_sur, ln_bsupvmnc_sur,
@@ -127,7 +127,7 @@
      2             mnpotdim = (/'mn_mode_pot'/),
      3             currg = (/'ext_current'/),
      4             currl = (/'current_label'/)
-      CHARACTER(LEN=*), DIMENSION(2), PARAMETER :: 
+      CHARACTER(LEN=*), DIMENSION(2), PARAMETER ::
      1             r2dim = (/'mn_mode','radius '/),
      1             r3dim = (/'mn_mode_nyq','radius     '/)
 #endif
@@ -138,15 +138,15 @@
      1           m, n, k, iwout0, n1, nwout, istat, i, indx1(1),
      2           mnmax_nyq0, mnyq0, nnyq0, nwout2   ! nwout2 by J.Geiger
      3          ,isgn, js2, nfort      !for diagno 1.5
-      REAL(dp) :: dmult, tcosi, tsini, vversion, sgn, tmult, 
+      REAL(dp) :: dmult, tcosi, tsini, vversion, sgn, tmult,
      1            presfactor, ftolx1, d_bsupumn, d_bsupvmn   ! diagno 1.5
 #ifdef _ANIMEC
      2              ,hotdam, omtbc, optbc, pdh, pmh, pde, pme, eps
 #endif
-      REAL(dp), POINTER, DIMENSION(:,:) :: rmnc, rmns, zmns, 
+      REAL(dp), POINTER, DIMENSION(:,:) :: rmnc, rmns, zmns,
      1   zmnc, lmns, lmnc
-      REAL(dp), ALLOCATABLE, DIMENSION(:,:) :: 
-     1   gmnc, bmnc, gmns, bmns, 
+      REAL(dp), ALLOCATABLE, DIMENSION(:,:) ::
+     1   gmnc, bmnc, gmns, bmns,
      2   bsubumnc, bsubvmnc, bsubsmns, bsubumns, bsubvmns, bsubsmnc,
      3   currumnc, currvmnc, currumns, currvmns
 #ifdef _ANIMEC
@@ -154,7 +154,7 @@
      4   hotdmnc , hotdmns ,
      5   sigmns  , taumns  , pparmns , ppermns , pbprmns , ppprmns
       REAL(dp), DIMENSION(:,:), ALLOCATABLE :: sigma_ana, tau_ana,
-     1                      ppara, pperpa, pbprima, ppprima, densita     
+     1                      ppara, pperpa, pbprima, ppprima, densita
 #endif
       REAL(dp), DIMENSION(mnmax) :: rmnc1, zmns1, lmns1,
      1   rmns1, zmnc1, lmnc1, bmodmn, bmodmn1
@@ -179,7 +179,7 @@
       REAL(dp), DIMENSION(:), ALLOCATABLE :: xfinal
       REAL(dp), DIMENSION(:), POINTER ::   xm_nyq0, xn_nyq0
 !     ELIMINATE THESE EVENTUALLY
-      REAL(dp), ALLOCATABLE, DIMENSION(:,:) :: 
+      REAL(dp), ALLOCATABLE, DIMENSION(:,:) ::
      1   bsupumnc, bsupumns, bsupvmnc, bsupvmns
 
       LOGICAL :: lcurr
@@ -222,8 +222,8 @@
       END IF
 
       ALLOCATE (gmn(mnmax_nyq0), bmn(mnmax_nyq0),
-     1   bsubumn(mnmax_nyq0), bsubvmn(mnmax_nyq0), bsubsmn(mnmax_nyq0), 
-     2   bsupumn(mnmax_nyq0), bsupvmn(mnmax_nyq0), 
+     1   bsubumn(mnmax_nyq0), bsubvmn(mnmax_nyq0), bsubsmn(mnmax_nyq0),
+     2   bsupumn(mnmax_nyq0), bsupvmn(mnmax_nyq0),
 #ifdef _ANIMEC
      3   sigmn(mnmax_nyq0)  ,
      4   taumn(mnmax_nyq0)  , pparmn(mnmax_nyq0) , ppermn(mnmax_nyq0) ,
@@ -248,7 +248,7 @@
       ALLOCATE (gmnc(mnmax_nyq0,ns), bmnc(mnmax_nyq0,ns),
      1          bsubumnc(mnmax_nyq0,ns), bsubvmnc(mnmax_nyq0,ns),
      2          bsubsmns(mnmax_nyq0,ns), bsupumnc(mnmax_nyq0,ns),
-     3          bsupvmnc(mnmax_nyq0,ns), 
+     3          bsupvmnc(mnmax_nyq0,ns),
      4          currumnc(mnmax_nyq0,ns), currvmnc(mnmax_nyq0,ns),
 #ifdef _ANIMEC
      5          sigmnc(mnmax_nyq0,ns)  ,
@@ -303,11 +303,11 @@
       wout_file = 'wout_' // TRIM(input_extension) // '.nc'
       CALL cdf_open(nwout,wout_file,'w',iwout0)
       IF (iwout0 .ne. 0) STOP 'Error opening wout.nc file VMEC WROUT'
-      
+
 !================================
 ! Define Variables
 !================================
-!  Scalars 
+!  Scalars
       CALL cdf_define(nwout, vn_version, vversion)
       CALL cdf_define(nwout, vn_extension, input_extension)
       CALL cdf_define(nwout, vn_mgrid, mgrid_file)
@@ -325,6 +325,10 @@
       CALL cdf_define(nwout, vn_polmod, mpol)
       CALL cdf_define(nwout, vn_tormod, ntor)
       CALL cdf_define(nwout, vn_maxmod, mnmax)
+      CALL cdf_define(nwout, vn_mnyq, mnyq0)
+      CALL cdf_setatt(nwout, vn_mnyq, ln_mnyq)
+      CALL cdf_define(nwout, vn_nnyq, nnyq0)
+      CALL cdf_setatt(nwout, vn_nnyq, ln_nnyq)
       CALL cdf_define(nwout, vn_maxmod_nyq, mnmax_nyq0)
       CALL cdf_define(nwout, vn_maxit, iter2)
       CALL cdf_define(nwout, vn_actit, itfsq)
@@ -355,7 +359,7 @@
       CALL cdf_define(nwout, vn_fsqz, fsqz)
 
       CALL cdf_define(nwout, vn_nextcur, nextcur)
-      CALL cdf_define(nwout, vn_extcur, extcur(1:nextcur), 
+      CALL cdf_define(nwout, vn_extcur, extcur(1:nextcur),
      1                dimname=currg)
       CALL cdf_define(nwout, vn_mgmode, mgrid_mode)
       IF (lfreeb) THEN
@@ -363,7 +367,7 @@
          CALL cdf_define(nwout, vn_flp, nobser)
          CALL cdf_define(nwout, vn_nobd, nobd)
          CALL cdf_define(nwout, vn_nbset, nbsets)
-         IF (nbsets .gt. 0) 
+         IF (nbsets .gt. 0)
      1      CALL cdf_define(nwout,vn_nbfld,nbfld(1:nbsets))
       END IF
 
@@ -380,17 +384,17 @@
       CALL cdf_define(nwout, vn_tmod_nyq, xn_nyq0, dimname=mn2dim)
       CALL cdf_setatt(nwout, vn_tmod_nyq, ln_tmod_nyq)
 
-      CALL cdf_define(nwout, vn_racc, raxis_cc(0:ntor), 
+      CALL cdf_define(nwout, vn_racc, raxis_cc(0:ntor),
      1                dimname=(/'n_tor'/))
       CALL cdf_setatt(nwout, vn_racc, ln_racc)
-      CALL cdf_define(nwout, vn_zacs, zaxis_cs(0:ntor), 
+      CALL cdf_define(nwout, vn_zacs, zaxis_cs(0:ntor),
      1                dimname=(/'n_tor'/))
       CALL cdf_setatt(nwout, vn_zacs, ln_zacs)
       IF (lasym) THEN
-         CALL cdf_define(nwout, vn_racs, raxis_cs(0:ntor), 
+         CALL cdf_define(nwout, vn_racs, raxis_cs(0:ntor),
      1                dimname=(/'n_tor'/))
          CALL cdf_setatt(nwout, vn_racs, ln_racs)
-         CALL cdf_define(nwout, vn_zacc, zaxis_cc(0:ntor), 
+         CALL cdf_define(nwout, vn_zacc, zaxis_cc(0:ntor),
      1                dimname=(/'n_tor'/))
          CALL cdf_setatt(nwout, vn_zacc, ln_zacc)
       END IF
@@ -404,7 +408,7 @@
       j = SIZE(ai)-1
       CALL cdf_define(nwout, vn_ai, ai(0:j),
      1                dimname=(/'preset'/))
-     
+
       max_am_aux = minloc(am_aux_s(2:),dim=1)
       CALL cdf_define(nwout, vn_am_aux_s, am_aux_s(1:max_am_aux),
      &                dimname=(/'max_am_aux'/))
@@ -421,58 +425,58 @@
       CALL cdf_define(nwout, vn_ac_aux_f, ac_aux_f(1:max_ac_aux),
      &                dimname=(/'max_ac_aux'/))
 
-      CALL cdf_define(nwout, vn_iotaf, iotaf(1:ns), 
+      CALL cdf_define(nwout, vn_iotaf, iotaf(1:ns),
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_iotaf, ln_iotaf)
 
       qfact=HUGE(qfact)
       WHERE (iotaf(1:ns) .NE. zero) qfact=one/iotaf(1:ns)
 
-      CALL cdf_define(nwout, vn_qfact, qfact(1:ns), 
+      CALL cdf_define(nwout, vn_qfact, qfact(1:ns),
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_iotaf, ln_qfact)
-      CALL cdf_define(nwout, vn_presf, presf, 
+      CALL cdf_define(nwout, vn_presf, presf,
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_presf, ln_presf, units='Pa')
-      CALL cdf_define(nwout, vn_phi, phi, 
+      CALL cdf_define(nwout, vn_phi, phi,
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_phi, ln_phi, units='wb')
-      CALL cdf_define(nwout, vn_phipf, 
+      CALL cdf_define(nwout, vn_phipf,
      1                phipf, dimname=r1dim)
       CALL cdf_setatt(nwout, vn_phipf, ln_phipf)
-      CALL cdf_define(nwout, vn_chi, chi, 
+      CALL cdf_define(nwout, vn_chi, chi,
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_chi, ln_chi, units='wb')
-      CALL cdf_define(nwout, vn_chipf, 
+      CALL cdf_define(nwout, vn_chipf,
      1                phipf, dimname=r1dim)
       CALL cdf_setatt(nwout, vn_chipf, ln_chipf)
-      CALL cdf_define(nwout, vn_jcuru, 
+      CALL cdf_define(nwout, vn_jcuru,
      1                jcuru, dimname=r1dim)
-      CALL cdf_define(nwout, vn_jcurv, 
+      CALL cdf_define(nwout, vn_jcurv,
      1                jcurv, dimname=r1dim)
- 
-      CALL cdf_define(nwout, vn_iotah, iotas(1:ns), 
+
+      CALL cdf_define(nwout, vn_iotah, iotas(1:ns),
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_iotah, ln_iotah)
-      CALL cdf_define(nwout, vn_mass, mass, 
+      CALL cdf_define(nwout, vn_mass, mass,
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_mass, ln_mass)
-      CALL cdf_define(nwout, vn_presh, pres(1:ns), 
+      CALL cdf_define(nwout, vn_presh, pres(1:ns),
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_presh, ln_presh, units='Pa')
-      CALL cdf_define(nwout, vn_betah, beta_vol, 
+      CALL cdf_define(nwout, vn_betah, beta_vol,
      1                dimname=r1dim)
-      CALL cdf_define(nwout, vn_buco, buco, 
+      CALL cdf_define(nwout, vn_buco, buco,
      1                dimname=r1dim)
-      CALL cdf_define(nwout, vn_bvco, bvco, 
+      CALL cdf_define(nwout, vn_bvco, bvco,
      1                dimname=r1dim)
-      CALL cdf_define(nwout, vn_vp, vp(1:ns), 
+      CALL cdf_define(nwout, vn_vp, vp(1:ns),
      1                dimname=r1dim)
-      CALL cdf_define(nwout, vn_specw, specw, 
+      CALL cdf_define(nwout, vn_specw, specw,
      1                dimname=r1dim)
-      CALL cdf_define(nwout, vn_phip, 
+      CALL cdf_define(nwout, vn_phip,
      1                phips(1:ns), dimname=r1dim)
-      CALL cdf_define(nwout, vn_overr, 
+      CALL cdf_define(nwout, vn_overr,
      2                overr(1:ns), dimname=r1dim)
 
       CALL cdf_define(nwout, vn_jdotb, jdotb,
@@ -508,8 +512,8 @@
      1                   dimname=mnpotdim)
          CALL cdf_define(nwout, vn_xnpot, xnpot(1:mnpd),
      1                   dimname=mnpotdim)
-         IF (lasym) THEN 
-            CALL cdf_define(nwout, vn_potcos, 
+         IF (lasym) THEN
+            CALL cdf_define(nwout, vn_potcos,
      1                      potvac(1+mnpd:2*mnpd), dimname=mnpotdim)
             CALL cdf_setatt(nwout, vn_potcos, ln_potcos)
          END IF
@@ -562,16 +566,16 @@
       CALL cdf_define(nwout, vn_bsupumnc, bsupumnc, dimname=r3dim)
       CALL cdf_define(nwout, vn_bsupvmnc, bsupvmnc, dimname=r3dim)
 !     IF (lfreeb) THEN
-!         CALL cdf_define(nwout, vn_rbc, rbc, 
+!         CALL cdf_define(nwout, vn_rbc, rbc,
 !    1                dimname=(/'n_mode','m_mode'/))
 !         CALL cdf_setatt(nwout, vn_rbc, ln_rbc, units='m')
-!         CALL cdf_define(nwout, vn_zbs, zbs, 
+!         CALL cdf_define(nwout, vn_zbs, zbs,
 !    1                dimname=(/'n_mode','m_mode'/))
 !         CALL cdf_setatt(nwout, vn_zbs, ln_zbs, units='m')
 !        IF (lasym) THEN
-!           CALL cdf_define(nwout, vn_rbs, rbs, 
+!           CALL cdf_define(nwout, vn_rbs, rbs,
 !    1                dimname=(/'n_mode','m_mode'/))
-!           CALL cdf_define(nwout, vn_zbc, zbc, 
+!           CALL cdf_define(nwout, vn_zbc, zbc,
 !    1                dimname=(/'n_mode','m_mode'/))
 !        END IF
 !     END IF
@@ -643,6 +647,8 @@
       CALL cdf_write(nwout, vn_polmod, mpol)
       CALL cdf_write(nwout, vn_tormod, ntor)
       CALL cdf_write(nwout, vn_maxmod, mnmax)
+      CALL cdf_write(nwout, vn_mnyq, mnyq0)
+      CALL cdf_write(nwout, vn_nnyq, nnyq0)
       CALL cdf_write(nwout, vn_maxmod_nyq, mnmax_nyq0)
       CALL cdf_write(nwout, vn_maxit, iter2)
       CALL cdf_write(nwout, vn_actit, itfsq)
@@ -766,9 +772,9 @@
 !     Extrapolation of m=0 Lambda (cs) modes, which are not evolved at j=1, done in CONVERT
 !
       lk = ns*ntor1
-      IF (lthreed) CALL convert_sym  (xfinal(1+mns*(rss-1)+lk), 
+      IF (lthreed) CALL convert_sym  (xfinal(1+mns*(rss-1)+lk),
      1                                xfinal(1+irzloff+mns*(zcs-1)+lk))
-      IF (lasym)   CALL convert_asym (xfinal(1+mns*(rsc-1)+lk), 
+      IF (lasym)   CALL convert_asym (xfinal(1+mns*(rsc-1)+lk),
      1                                xfinal(1+irzloff+mns*(zcc-1)+lk))
 #endif
 !
@@ -778,7 +784,7 @@
 !
       RADIUS1: DO js = 1, ns
 
-         CALL convert (rmnc1, zmns1, lmns1, rmns1, zmnc1, lmnc1, 
+         CALL convert (rmnc1, zmns1, lmns1, rmns1, zmnc1, lmnc1,
      1                         xfinal, js)
 
          rmnc(:,js) = rmnc1(:)
@@ -801,29 +807,29 @@
 
       WHERE (NINT(xm) .le. 1) lmns(:,1) = lmns(:,2)
       DO js = ns,2,-1
-         WHERE (MOD(NINT(xm),2) .eq. 0) 
+         WHERE (MOD(NINT(xm),2) .eq. 0)
             lmns(:,js) = p5*(lmns(:,js) + lmns(:,js-1))
          ELSEWHERE
             lmns(:,js) = p5*(sm(js)*lmns(:,js) + sp(js-1)*lmns(:,js-1))
          END WHERE
       END DO
 
-      lmns(:,1) = 0  
+      lmns(:,1) = 0
       raxis_cc(0:ntor) = rmnc(1:ntor+1,1)
       zaxis_cs(0:ntor) = zmns(1:ntor+1,1)
-      
+
       IF (.NOT.lasym) GOTO 900
 
       WHERE (NINT(xm) .le. 1) lmnc(:,1) = lmnc(:,2)
       DO js = ns,2,-1
-         WHERE (MOD(NINT(xm),2) .eq. 0) 
+         WHERE (MOD(NINT(xm),2) .eq. 0)
             lmnc(:,js) = p5*(lmnc(:,js) + lmnc(:,js-1))
          ELSEWHERE
             lmnc(:,js) = p5*(sm(js)*lmnc(:,js) + sp(js-1)*lmnc(:,js-1))
          END WHERE
       END DO
 
-      lmnc(:,1) = 0;   
+      lmnc(:,1) = 0;
       raxis_cs(0:ntor) = rmns(1:ntor+1,1)
       zaxis_cc(0:ntor) = zmnc(1:ntor+1,1)
 
@@ -852,17 +858,17 @@
       pmap(ns) = pme
 !ALTERNATE EXTRAPOLATION
       pd(2) = 2*pd(3) - pd(4)
-      pd(ns) = 2*pd(ns-1) - pd(ns-2) 
+      pd(ns) = 2*pd(ns-1) - pd(ns-2)
 
 !CALCULATE HOT PARTICLE PARALLEL AND PERPENDICULAR PRESSURE GRADIENT; DENSITY
-      DO 20 js = 2, ns 
+      DO 20 js = 2, ns
         hotdam = pres(js) * phot(js) / SQRT(tpotb(js)+eps)
-        DO 10 lk = 1, nznt  
-!  
+        DO 10 lk = 1, nznt
+!
            omtbc = one - tpotb(js) * onembc(js,lk)
            optbc = one + tpotb(js) * onembc(js,lk)
         IF (onembc(js,lk) <= zero) THEN
-           densit(js,lk)= (ppar(js,lk) - pres(js))*hotdam / 
+           densit(js,lk)= (ppar(js,lk) - pres(js))*hotdam /
      &                    (pres(js)*phot(js)+eps)
            pbprim(js,lk) =  (ppar(js,lk) -pres(js)) *
      &             (pd(js) + onembc(js,lk) * pmap(js) / (omtbc+eps))
@@ -882,7 +888,7 @@
      &   * onembc(js,lk)*(two*optbc-sqrt(tpotb(js)*onembc(js,lk))*(7.5
      &   - 3.5_dp*(tpotb(js)*onembc(js,lk))**2))/(omtbc*optbc+eps))
      &   * pmap(js)/ (omtbc * optbc + eps)
-        END IF  
+        END IF
    10   END DO
    20  END DO
 #endif
@@ -898,7 +904,7 @@
          tmult = 2*tmult
          bsubs(1,:) = 0
          CALL symoutput (bsq,   gsqrt,  bsubu,  bsubv,  bsupu,
-     1                   bsupv,  bsubs, 
+     1                   bsupv,  bsubs,
 #ifdef _ANIMEC
      2                   ppar   , pperp  , densit ,
      3                   sigma_an , tau_an , pbprim , ppprim ,
@@ -943,7 +949,7 @@
             lk = 0
             DO j = 1, ntheta2
                DO k = 1, nzeta
-                  lk = lk + 1 
+                  lk = lk + 1
                   tcosi = dmult*(cosmui(j,m)*cosnv(k,n1) +
      1                       sgn*sinmui(j,m)*sinnv(k,n1))          !cos(mu - nv)
                   tsini = dmult*(sinmui(j,m)*cosnv(k,n1) -
@@ -953,8 +959,8 @@
                   bsubumn(mn) = bsubumn(mn) + tcosi*bsubu(js,lk)
                   bsubvmn(mn) = bsubvmn(mn) + tcosi*bsubv(js,lk)
                   bsubsmn(mn) = bsubsmn(mn) + tsini*bsubs(js,lk)
-                  bsupumn(mn) = bsupumn(mn) + tcosi*bsupu(js,lk) 
-                  bsupvmn(mn) = bsupvmn(mn) + tcosi*bsupv(js,lk) 
+                  bsupumn(mn) = bsupumn(mn) + tcosi*bsupu(js,lk)
+                  bsupvmn(mn) = bsupvmn(mn) + tcosi*bsupv(js,lk)
 #ifdef _ANIMEC
                   pparmn(mn)  = pparmn(mn)  + tcosi*
      1                                       (ppar(js,lk)-pres(js))
@@ -1030,7 +1036,7 @@
 #ifdef _ANIMEC
       hotdmnc(:,1)  = 0;  pparmnc(:,1)  = 0;  ppermnc(:,1) = 0
       pbprmnc(:,1)  = 0;  ppprmnc(:,1)  = 0
-      sigmnc(:,1)   = 0;  taumnc(:,1)   = 0   
+      sigmnc(:,1)   = 0;  taumnc(:,1)   = 0
 #endif
 
       IF (.not.lasym) GO TO 200
@@ -1089,7 +1095,7 @@
                END DO
             END DO
          END DO MN3
-   
+
          gmns(:,js) = gmn(:)
          bmns(:,js) = bmn(:)
          bsubumns(:,js) = bsubumn(:)
@@ -1116,7 +1122,7 @@
 #ifdef _ANIMEC
       hotdmns(:,1)  = 0;  pparmns(:,1)  = 0;  ppermns(:,1) = 0
       pbprmns(:,1)  = 0;  ppprmns(:,1)  = 0
-      sigmns(:,1)   = 0;  taumns(:,1)   = 0   
+      sigmns(:,1)   = 0;  taumns(:,1)   = 0
 #endif
 
       IF (lfreeb) THEN        !MRC  10-15-15
@@ -1166,7 +1172,7 @@
          DO js = 2,ns-1
             tmult=-xm_nyq0(mn)*bsubsmns(mn,js) +
      1                    ohs*(bsubumnc(mn,js+1)-bsubumnc(mn,js))
-            WRITE (333,'(i6,1p,3e12.4)') js, 
+            WRITE (333,'(i6,1p,3e12.4)') js,
      1                  bsubsmns(mn,js)*xm_nyq0(mn),
      2             ohs*(bsubumnc(mn,js+1)-bsubumnc(mn,js)),
      3             tmult
@@ -1219,7 +1225,7 @@
 !
 #ifdef NETCDF
       CALL cdf_write(nwout, vn_racc, raxis_cc(0:ntor))
-      CALL cdf_write(nwout, vn_zacs, zaxis_cs(0:ntor)) 
+      CALL cdf_write(nwout, vn_zacs, zaxis_cs(0:ntor))
       CALL cdf_write(nwout, vn_rmnc, rmnc)
       CALL cdf_write(nwout, vn_zmns, zmns)
       CALL cdf_write(nwout, vn_lmns, lmns)
@@ -1263,27 +1269,27 @@
 
       CALL cdf_write(nwout, vn_iotaf, iotaf(1:ns))
       CALL cdf_write(nwout, vn_qfact, qfact(1:ns))
-      CALL cdf_write(nwout, vn_presf, presf/mu0) 
-      CALL cdf_write(nwout, vn_phi, phi) 
+      CALL cdf_write(nwout, vn_presf, presf/mu0)
+      CALL cdf_write(nwout, vn_phi, phi)
       CALL cdf_write(nwout, vn_phipf, twopi*signgs*phipf)
-      CALL cdf_write(nwout, vn_chi, chi) 
+      CALL cdf_write(nwout, vn_chi, chi)
       CALL cdf_write(nwout, vn_chipf, twopi*signgs*chipf)
       CALL cdf_write(nwout, vn_jcuru, jcuru/mu0)
       CALL cdf_write(nwout, vn_jcurv, jcurv/mu0)
       CALL cdf_write(nwout, vn_jdotb, jdotb)
       CALL cdf_write(nwout, vn_bdotb, bdotb)
       CALL cdf_write(nwout, vn_bgrv, bdotgradv)
- 
+
 !     HALF-MESH quantities
-      iotas(1) = 0; mass(1) = 0; pres(1) = 0; phip(1) = 0; 
+      iotas(1) = 0; mass(1) = 0; pres(1) = 0; phip(1) = 0;
       buco(1) = 0; bvco(1) = 0; vp(1) = 0; overr(1) = 0;  specw(1) = 1
       beta_vol(1) = 0
       CALL cdf_write(nwout, vn_iotah, iotas(1:ns))
-      CALL cdf_write(nwout, vn_mass, mass/mu0) 
+      CALL cdf_write(nwout, vn_mass, mass/mu0)
       CALL cdf_write(nwout, vn_presh, pres(1:ns)/mu0)
       CALL cdf_write(nwout, vn_betah, beta_vol)
       CALL cdf_write(nwout, vn_buco, buco)
-      CALL cdf_write(nwout, vn_bvco, bvco) 
+      CALL cdf_write(nwout, vn_bvco, bvco)
       CALL cdf_write(nwout, vn_vp, vp(1:ns))
       CALL cdf_write(nwout, vn_specw, specw)
       CALL cdf_write(nwout, vn_phip, phips(1:ns))
@@ -1298,7 +1304,7 @@
       CALL cdf_write(nwout, vn_equif, equif(1:ns))
 
       CALL cdf_write(nwout, vn_fsq, fsqt(1:nstore_seq))
-      CALL cdf_write(nwout, vn_wdot, wdot(1:nstore_seq))  
+      CALL cdf_write(nwout, vn_wdot, wdot(1:nstore_seq))
 
 !-----------------------------------------------
 !     DATA AND MSE FITS : HAVE NOT CONVERTED TO NETCDF
@@ -1335,8 +1341,8 @@
      5               taumnc  (mn,js)
 #endif
                IF (lasym) THEN
-                  WRITE (nwout2, *) bmns(mn,js), gmns(mn,js), 
-     1               bsubumns(mn,js), bsubvmns(mn,js), bsubsmnc(mn,js), 
+                  WRITE (nwout2, *) bmns(mn,js), gmns(mn,js),
+     1               bsubumns(mn,js), bsubvmns(mn,js), bsubsmnc(mn,js),
      2               bsupumns(mn,js), bsupvmns(mn,js)
 #ifdef _ANIMEC
      3              ,pparmns (mn,js), ppermns (mn,js), hotdmns (mn,js),
@@ -1461,7 +1467,7 @@
 !-----------------------------------------------
 !  for diagno version 1.5 written by Sam Lazerson (SAL) start
 !-----------------------------------------------
-      IF(ldiagno)THEN         
+      IF(ldiagno)THEN
          IF(lfreeb .and. (.not.lasym))THEN
             nfort = 21
             fort_file = 'diagno1.5_in.'//input_extension
@@ -1482,7 +1488,7 @@
             DO i = 1, mnpd
                write(21,'(1p,e24.16)') potvac(i)
             END DO
-            
+
 !-----  Added by SAL 11/2010
             write(21,*) "bsupu"
             js=ns
@@ -1501,7 +1507,7 @@
                         lk = k + nzeta*(j - 1)
                         tcosi = dmult*(cosmui(j,m)*cosnv(k,n1) +
      1                            isgn*sinmui(j,m)*sinnv(k,n1))
-                        d_bsupumn = d_bsupumn + 1.5*tcosi*bsupu(js,lk) 
+                        d_bsupumn = d_bsupumn + 1.5*tcosi*bsupu(js,lk)
      1                                    - 0.5*tcosi*bsupu(js2,lk)
                      end do
                   end do
@@ -1526,14 +1532,14 @@
                         lk = k + nzeta*(j - 1)
                         tcosi = dmult*(cosmui(j,m)*cosnv(k,n1) +
      1                            isgn*sinmui(j,m)*sinnv(k,n1))
-                        d_bsupvmn = d_bsupvmn + 1.5*tcosi*bsupv(js,lk) 
+                        d_bsupvmn = d_bsupvmn + 1.5*tcosi*bsupv(js,lk)
      1                                    - 0.5*tcosi*bsupv(js2,lk)
                      end do
                   end do
                   write (21,'(1p,e24.16)') d_bsupvmn
                end do
             end do
-            
+
             write(21,*) "phiedge"
             write(21,*) phiedge
             write(21,*) "nextcur"
@@ -1569,12 +1575,12 @@
 #ifdef NETCDF
       IF (lasym) THEN
          CALL cdf_write(nwout, vn_racs, raxis_cs(0:ntor))
-         CALL cdf_write(nwout, vn_zacc, zaxis_cc(0:ntor)) 
+         CALL cdf_write(nwout, vn_zacc, zaxis_cc(0:ntor))
          CALL cdf_write(nwout, vn_rmns, rmns)
          CALL cdf_write(nwout, vn_zmnc, zmnc)
          CALL cdf_write(nwout, vn_lmnc, lmnc)
          CALL cdf_write(nwout, vn_gmns, gmns)
-         CALL cdf_write(nwout, vn_bmns, bmns) 
+         CALL cdf_write(nwout, vn_bmns, bmns)
          CALL cdf_write(nwout, vn_bsubumns, bsubumns)
          CALL cdf_write(nwout, vn_bsubvmns, bsubvmns)
          CALL cdf_write(nwout, vn_bsubsmnc, bsubsmnc)


### PR DESCRIPTION
I added `mnyq` and `nyyq` to the netCDF wout file.
The contents of these variables are initialized from `mnyq0` and `nyyq0` to take into account the `lnyquist` flag.

Spurious whitespace at the end of the lines has been removed; sorry for the mess in the diff.
Please let me know if this is a problem.

This PR needs `https://github.com/ORNL-Fusion/LIBSTELL/pull/34`.