### PR TITLE
cache LU decomposition in NESTOR instead of re-doing it in every solve

### DIFF
--- a/Sources/Initialization_Cleanup/allocate_nunv.f
+++ b/Sources/Initialization_Cleanup/allocate_nunv.f
@@ -21,10 +21,13 @@ C-----------------------------------------------
       IF (istat1.ne.0) STOP 'allocation error #2 in allocate_nunv'
 
 !     PERSISTENT ARRAYS (DURATION OF PROGRAM)
-      IF (lfreeb)
-     1   ALLOCATE (amatsav(mnpd2*mnpd2),bvecsav(mnpd2),
-     2          bsqsav(nznt,3), potvac(2*mnpd), raxis_nestor(nv),
-     3          zaxis_nestor(nv), stat=istat1)
+      IF (lfreeb) then
+         ALLOCATE (amatsav(mnpd2*mnpd2),bvecsav(mnpd2),
+     &          bsqsav(nznt,3), potvac(2*mnpd), raxis_nestor(nv),
+     &          zaxis_nestor(nv), stat=istat1)
          IF (istat1.ne.0) STOP 'allocation error #3 in allocate_nunv'
+         ALLOCATE (ipiv(mnpd2), stat=istat1)
+         IF (istat1.ne.0) STOP 'allocation error #4 in allocate_nunv'
+      end if
 
       END SUBROUTINE allocate_nunv

--- a/Sources/NESTOR_vacuum/scalpot.f
+++ b/Sources/NESTOR_vacuum/scalpot.f
@@ -15,6 +15,9 @@ C-----------------------------------------------
       REAL(dp), ALLOCATABLE :: grpmn(:), green(:), gstore(:)
       REAL(dp), ALLOCATABLE :: greenp(:,:)
       REAL(dp) :: ton, toff, tonscal
+
+      integer :: info
+
 C-----------------------------------------------
       CALL second0(tonscal)
 
@@ -108,6 +111,10 @@ C-----------------------------------------------
          CALL fouri (grpmn, gstore, amatrix, amatsav, bvec, 
      &               bvecsav, ndim)
          DEALLOCATE (green, greenp, gstore)
+
+         info = 0
+         call dgetrf(mnpd2, mnpd2, amatsav, mnpd2, ipiv, info)
+         IF (info .ne. 0) PRINT *, ' dgetrf error in scalpot'
 
       END IF
 

--- a/Sources/NESTOR_vacuum/vacmod.f
+++ b/Sources/NESTOR_vacuum/vacmod.f
@@ -21,6 +21,7 @@ C-----------------------------------------------
      2   zub, zvb, bexu, bexv, bexn, auu, auv, avv, snr, snv, snz, drv,
      3   guu_b, guv_b, gvv_b, rzb2, rcosuv, rsinuv,
      5   bredge, bpedge, bzedge
+      INTEGER, ALLOCATABLE :: ipiv(:)
       REAL(rprec), DIMENSION(:), ALLOCATABLE :: raxis_nestor, 
      1                                          zaxis_nestor
       REAL(rprec) :: bsubvvac, pi2,

--- a/Sources/NESTOR_vacuum/vacuum.f
+++ b/Sources/NESTOR_vacuum/vacuum.f
@@ -99,7 +99,10 @@ C-----------------------------------------------
       timer_vac(tscal) = timer_vac(tscal) + (toff-ton)
 
       ton = toff
-      CALL solver (amatrix, potvac, mnpd2, 1, info)
+      info = 0
+      call dgetrs('No transpose', mnpd2, 1, amatrix, mnpd2, 
+     &            ipiv, potvac, mnpd2, info)
+      IF (info .ne. 0) PRINT *, ' dgetrf error in scalpot'
       CALL second0(toff)
       timer_vac(tsolver) = timer_vac(tsolver) + (toff-ton)
       solver_time = solver_time + (toff - ton)


### PR DESCRIPTION
In NESTOR, the matrix `amatrix` is cached if `ivacskip .ne. 0`. However, the `solver` call in `vacuum.f` always needs to perform the LU decomposition from scratch, even though the matrix never changes. The changes in this PR make NESTOR compute the LU decomposition (using `dgetrf`) only if the matrix changed and thus perform only the solve step (`dgetrs`) in every iteration.
This leads to quite some speedup for free-boundary VMEC.
None of the results should change in any way, since `dgesv` (used by the previous `solver` in `solver.f`) internally also just calls `dgetrf` and `dgetrs` (see (`dgesv.f`)[https://netlib.org/lapack/explore-html/d8/d72/dgesv_8f_source.html]).