### PR TITLE
[FIX] Gauss-Legendre poles and weights in profile_functions.f

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -55,10 +55,16 @@ jobs:
               shell: bash
               working-directory: ${{runner.workspace}}/Stellarator-Tools/build
               run: make -j VERBOSE=1
-            - name: Test
+            - name: Test Mac
+              if: ${{matrix.os == 'macos-latest'}}
               shell: bash
               working-directory: ${{runner.workspace}}/Stellarator-Tools/build
-              run: make test
+              run: make test ARGS=-j3
+            - name: Test Linux
+              if: ${{matrix.os == 'ubuntu-latest'}}
+              shell: bash
+              working-directory: ${{runner.workspace}}/Stellarator-Tools/build
+              run: make test ARGS=-j2
             - name: Show Log
               if: failure()
               shell: bash

--- a/.github/workflows/ci_test_master.yaml
+++ b/.github/workflows/ci_test_master.yaml
@@ -55,10 +55,16 @@ jobs:
               shell: bash
               working-directory: ${{runner.workspace}}/Stellarator-Tools/build
               run: make -j VERBOSE=1
-            - name: Test
+            - name: Test Mac
+              if: ${{matrix.os == 'macos-latest'}}
               shell: bash
               working-directory: ${{runner.workspace}}/Stellarator-Tools/build
-              run: make test
+              run: make test ARGS=-j3
+            - name: Test Linux
+              if: ${{matrix.os == 'ubuntu-latest'}}
+              shell: bash
+              working-directory: ${{runner.workspace}}/Stellarator-Tools/build
+              run: make test ARGS=-j2
             - name: Show Log
               if: failure()
               shell: bash

--- a/Sources/Initialization_Cleanup/profile_functions.f
+++ b/Sources/Initialization_Cleanup/profile_functions.f
@@ -4,7 +4,7 @@
 !    FUNCTION pmass
 !  (JDH 2010-03-30)
 !******************************************************************************
-      
+
       FUNCTION pcurr (xx)
 !  Function to compute the current profile
 
@@ -24,10 +24,10 @@
 !                          ac(0) * ((1 - s ** ac(1)) ** ac(2))*(1 + Sum[ac(i)*Exp(-(s - ac(i+1))/ac(i+2)) ** 2])
 !    sum_atan         _    sum of arctangents
 !    power_series_I   _    Power series for I(s) (NOT default)
-!    Akima_spline_Ip  X    Akima spline for I-prime(s) 
-!    Akima_spline_I   _    Akima spline for I(s) 
-!    cubic_spline_Ip  X    cubic spline for I-prime(s) 
-!    cubic_spline_I   _    cubic spline for I(s) 
+!    Akima_spline_Ip  X    Akima spline for I-prime(s)
+!    Akima_spline_I   _    Akima spline for I(s)
+!    cubic_spline_Ip  X    cubic spline for I-prime(s)
+!    cubic_spline_I   _    cubic spline for I(s)
 !    pedestal         _    Pedestal profile
 !    rational         _    Rational function (ratio of polynomials)
 !    line_segment_Ip  X    Line segments for I-prime(s)
@@ -50,7 +50,7 @@
 !  Note that the profile that is parameterized is often I-prime, whereas
 !  I(x) (= Integral_from_0_to_x I-prime(s) ds) is the function that pcurr
 !  returns. For the default case of a power series, the integral can be
-!  computed analytically. For other cases, a numerical quadrature is done, 
+!  computed analytically. For other cases, a numerical quadrature is done,
 !  using a 10-point Gauss-Legendre quadrature.
       USE stel_kinds
       USE stel_constants, ONLY: zero, one, pi
@@ -58,24 +58,36 @@
       USE line_segment
       USE functions
       IMPLICIT NONE
-! ac assumed to be dimensioned (0:n), with n >= 20 
+! ac assumed to be dimensioned (0:n), with n >= 20
 !-----------------------------------------------
       INTEGER     :: i, ioff, iflag
       REAL(rprec) :: xx, pcurr, x, xp, temp_num, temp_denom
       CHARACTER(len=20) :: pcurr_type_lc
-      
+
       INTEGER, PARAMETER          :: gln = 10
       INTEGER                     :: gli
-      REAL(rprec), DIMENSION(gln), PARAMETER :: glx = (/                       &
-     &   0.01304673574141414, 0.06746831665550774, 0.1602952158504878,         &
-     &   0.2833023029353764, 0.4255628305091844, 0.5744371694908156,           &
-     &   0.7166976970646236, 0.8397047841495122, 0.9325316833444923,           &
-     &   0.9869532642585859 /)
-      REAL(rprec), DIMENSION(gln), PARAMETER :: glw = (/                       &
-     &   0.03333567215434407, 0.0747256745752903, 0.1095431812579910,          &
-     &   0.1346333596549982, 0.1477621123573764, 0.1477621123573764,           &
-     &   0.1346333596549982, 0.1095431812579910, 0.0747256745752903,           &
-     &   0.03333567215434407 /)
+      REAL(rprec), DIMENSION(gln), PARAMETER :: glx = (/
+     &   0.01304673574141414_rprec,
+     &   0.06746831665550774_rprec,
+     &   0.1602952158504878_rprec,
+     &   0.2833023029353764_rprec,
+     &   0.4255628305091844_rprec,
+     &   0.5744371694908156_rprec,
+     &   0.7166976970646236_rprec,
+     &   0.8397047841495122_rprec,
+     &   0.9325316833444923_rprec,
+     &   0.9869532642585859_rprec /)
+      REAL(rprec), DIMENSION(gln), PARAMETER :: glw = (/
+     &   0.03333567215434407_rprec,
+     &   0.0747256745752903_rprec,
+     &   0.1095431812579910_rprec,
+     &   0.1346333596549982_rprec,
+     &   0.1477621123573764_rprec,
+     &   0.1477621123573764_rprec,
+     &   0.1346333596549982_rprec,
+     &   0.1095431812579910_rprec,
+     &   0.0747256745752903_rprec,
+     &   0.03333567215434407_rprec /)
       REAL(rprec) :: g1,g2,g3,g4,a8,a12
       REAL(rprec), dimension(21) :: xi, bsta, bend, wd
       REAL(rprec) :: sqx,delx,delxsq,pisq
@@ -98,7 +110,7 @@
       pcurr_type_lc = pcurr_type
       CALL tolower(pcurr_type_lc)
       SELECT CASE(TRIM(pcurr_type_lc))
-      
+
       CASE ('sum_cossq_s')
 ! 20180218, Joachim Geiger
 ! The idea was to use the combination of cos**2-waves located at
@@ -108,9 +120,9 @@
 !  Sum of ncssq cos**2 terms put at different radial locations
 !  and with a windowing around the maxima as current density:
 !  ac(0) holds ncssq
-!     ac(1)*(H(x)-H(x-dx))*(cos(pi*(x-xi(1))/(2*dx))**2 
+!     ac(1)*(H(x)-H(x-dx))*(cos(pi*(x-xi(1))/(2*dx))**2
 !    +ac(2)*(H(x-(xi(2)-dx))-H(x-(xi(2)+dx)))*cos(pi*(x-xi(2))/(2*dx))**2
-!    + ... 
+!    + ...
 !    +ac(ncssq)*(H(x-(xi(ncssq)-dx))-H(x-(xi(ncssq))))*cos(pi*(x-xi(ncssq))/(2*dx))**2
 !  windowing is done with the Heavyside-functions producing the
 !  Boxcar Function: H(x-a)-H(x-b) is, for a<b, 1 for a<x<b and zero otherwise.
@@ -136,7 +148,7 @@
 !
       ncssq=int(ac(0))
       if (ncssq .lt. 1 .or. ncssq .gt. 20) then
-        write(6,*) "Number of coeff.s for sum_cos_sq :",  
+        write(6,*) "Number of coeff.s for sum_cos_sq :",
      &             "1<= sum_cos_sq <= 21!"
         stop 'Check input!'
       endif
@@ -181,9 +193,9 @@
 !  Sum of ncssq cos**2 terms put at different radial locations
 !  and with a windowing around the maxima as current density:
 !  ac(0) holds ncssq
-!     ac(1)*(H(x)-H(x-dx))*(cos(pi*(x-xi(1))/(2*dx))**2 
+!     ac(1)*(H(x)-H(x-dx))*(cos(pi*(x-xi(1))/(2*dx))**2
 !    +ac(2)*(H(x-(xi(2)-dx))-H(x-(xi(2)+dx)))*cos(pi*(x-xi(2))/(2*dx))**2
-!    + ... 
+!    + ...
 !    +ac(ncssq)*(H(x-(xi(ncssq)-dx))-H(x-(xi(ncssq))))*cos(pi*(x-xi(ncssq))/(2*dx))**2
 !  windowing is done with the Heavyside-functions producing the
 !  Boxcar Function: H(x-a)-H(x-b) is, for a<b, 1 for a<x<b and zero otherwise.
@@ -213,7 +225,7 @@
 !
       ncssq=int(ac(0))
       if (ncssq .lt. 1 .or. ncssq .gt. 20) then
-        write(6,*) "Number of coeff.s for sum_cos_sq :",  
+        write(6,*) "Number of coeff.s for sum_cos_sq :",
      &             "1<= sum_cos_sq <= 21!"
         stop 'Check input!'
       endif
@@ -280,7 +292,7 @@
 !  ac(0) holds ncssq
 !     ac(0)*(H(x-(ac(1)-ac(2)/2.))-H(x-(ac(1)+ac(2)/2.)))*cos(pi*(x-ac(1))/(ac(2)))**2
 !    +ac(3)*(H(x-(ac(4)-ac(5)/2.))-H(x-(ac(4)+ac(5)/2.)))*cos(pi*(x-ac(4))/(ac(5)))**2
-!    + ... 
+!    + ...
 !    +ac(18)*(H(x-(ac(19)-ac(20)/2.))-H(x-(ac(19)+ac(20)/2.)))*cos(pi*(x-ac(19))/(ac(20)))**2
 !  windowing is done with the Heavyside-functions producing the
 !  Boxcar Function: H(x-a)-H(x-b) is, for a<b, 1 for a<x<b and zero otherwise.
@@ -330,7 +342,7 @@
      &         - exp(-(1 / ac(1)) ** 2))
          END DO
          pcurr = pcurr * x     ! correct for x interval
-         
+
       CASE ('two_power')
 !  Two power profile
 !  I-prime(s) = [1 - s**ac(0)]**ac(1)            !! Old as of 2010-05-26
@@ -359,7 +371,7 @@
 !     &         ac(5) * (2/pi) * atan(ac(6)*x**ac(7)/(1-x)**ac(8)) +            &
 !     &         ac(9) * (2/pi) * atan(ac(10)*x**ac(11)/(1-x)**ac(12)) +         &
 !     &         ac(13) * (2/pi) * atan(ac(14)*x**ac(15)/(1-x)**ac(16)) +        &
-!     &         ac(17) * (2/pi) * atan(ac(18)*x**ac(19)/(1-x)**ac(20)) 
+!     &         ac(17) * (2/pi) * atan(ac(18)*x**ac(19)/(1-x)**ac(20))
       IF (x .ge. one) THEN
          pcurr = ac(0) + ac(1) + ac(5) + ac(9) + ac(13) + ac(17)
       ELSE
@@ -380,7 +392,7 @@
        DO i = UBOUND(ac,1), ioff, -1
         pcurr = (pcurr + ac(i))*x
        END DO
-       
+
       CASE('Akima_spline_I','akima_spline_i') ! former ipcurr=11
 !  I(s) with Akima splines
 !  Akima-spline for current profile
@@ -476,21 +488,21 @@
 
          a8 =MAX(ac(i+8),0.01_dp)
          a12=MAX(ac(i+12),0.01_dp)
-      
+
          g1= (x-ac(i+7))/a8
          g3= (-ac(i+7))/a8
          g2= (x-ac(i+11))/a12
-         g4= (-ac(i+11))/a12      
+         g4= (-ac(i+11))/a12
          pcurr = pcurr + ac(i+4) * ac(i+0) *
      1 ( TANH( 2*ac(i+2)/ac(i+3) )
      2  -TANH( 2*(ac(i+2)-SQRT(x))/ac(i+3) ) )
      3  +ac(i+5)*( TANH(g1) - TANH(g3) )
      4  +ac(i+9)*( TANH(g2) - TANH(g4) )
 
-      
-      CASE('rational') ! 
+
+      CASE('rational') !
 !  I(s)  - not I-prime(s). No need for Gaussian quadrature.
-!  Ratio of polynomials. 
+!  Ratio of polynomials.
 !  Numerator coefficients: ac(LBOUND) - ac(9)
 !  Denominator coefficients: ac(10) - ac(UBOUND(ac,1))
          temp_num = zero
@@ -506,13 +518,13 @@
          ELSE
             pcurr = HUGE(pcurr)
          ENDIF
-      
+
       CASE('line_segment_Ip', 'line_segment_ip')
 !  I(s) from I-prime(s)-values. Integrated line segments to determine the plasma
 !  current.
          i = minloc(ac_aux_s(2:),dim=1)
          CALL line_seg_int(x,pcurr,ac_aux_s,ac_aux_f,i)
-      
+
       CASE('line_segment_I', 'line_segment_i')
 !  I(s) values. Linearly interpolated line segments to determine the plasma
 !  current.
@@ -521,16 +533,16 @@
 
       CASE DEFAULT
 !  Power series
-!  I-prime(s) = Sum(i,0,-)[ac(i) * s ** i] 
+!  I-prime(s) = Sum(i,0,-)[ac(i) * s ** i]
 !  Analytic integration to get I(s)
          DO i = UBOUND(ac,1), ioff, -1
             pcurr = x*pcurr + ac(i)/(i-ioff+1)
          END DO
          IF (TRIM(pcurr_type_lc) .ne. 'power_series') THEN
-            WRITE(*,*) 'Unrecognized pcurr_type:', pcurr_type 
+            WRITE(*,*) 'Unrecognized pcurr_type:', pcurr_type
             WRITE(*,*) ' *** CHECK YOUR INPUT ***'
             WRITE(*,*) 'Changing pcurr_type from ''',                          &
-     &         TRIM(pcurr_type), '''to ''power_series''.' 
+     &         TRIM(pcurr_type), '''to ''power_series''.'
             pcurr_type = 'power_series'
          END IF
          pcurr = x*pcurr
@@ -539,7 +551,7 @@
       END FUNCTION pcurr
 
 !******************************************************************************
-      
+
       FUNCTION piota (x)
 !  Function to compute the iota/q profile.
 
@@ -549,7 +561,7 @@
 !  ai_aux_f         Auxiliary array f, function-values used for splines
 !  piota_type       character, specifies the parameterization of the profile
 !    sum_atan        Sum of atan functions plus offset.
-!    Akima_spline      Akima spline 
+!    Akima_spline      Akima spline
 !    cubic_spline      cubic spline
 !    rational          rational (ratio of polynomials)
 !    nice_quadratic    quadratic with rerranged coefficients.
@@ -571,7 +583,7 @@
       USE vmec_input, ONLY: ai, piota_type, ai_aux_s, ai_aux_f, lRFP
       USE line_segment
       IMPLICIT NONE
-! ai assumed to be dimensioned (0:n), with n >= 20 
+! ai assumed to be dimensioned (0:n), with n >= 20
 !-----------------------------------------------
       INTEGER     :: i, iflag, ioff
       REAL(rprec), INTENT(IN) :: x
@@ -586,14 +598,14 @@
       CALL tolower(piota_type_lc)
       SELECT CASE(TRIM(piota_type_lc))
 
-      CASE('sum_atan') 
+      CASE('sum_atan')
 !  Sum atan functions mapped to  [0:1], with an ai(0) offset
 !       piota = ai(0) +                                                         &
 !     &         ai(1) * (2/pi) * atan(ai(2)*x**ai(3)/(1-x)**ai(4)) +            &
 !     &         ai(5) * (2/pi) * atan(ai(6)*x**ai(7)/(1-x)**ai(8)) +            &
 !     &         ai(9) * (2/pi) * atan(ai(10)*x**ai(11)/(1-x)**ai(12)) +         &
 !     &         ai(13) * (2/pi) * atan(ai(14)*x**ai(15)/(1-x)**ai(16)) +        &
-!     &         ai(17) * (2/pi) * atan(ai(18)*x**ai(19)/(1-x)**ai(20)) 
+!     &         ai(17) * (2/pi) * atan(ai(18)*x**ai(19)/(1-x)**ai(20))
       IF (x .ge. one) THEN
          piota = ai(0) + ai(1) + ai(5) + ai(9) + ai(13) + ai(17)
       ELSE
@@ -604,7 +616,7 @@
      &                 ai(13) * atan(ai(14)*x**ai(15)/(1-x)**ai(16)) +         &
      &                 ai(17) * atan(ai(18)*x**ai(19)/(1-x)**ai(20)))
       ENDIF
-     
+
       CASE('Akima_spline','akima_spline') ! former ipiota=11
 ! Akima-spline   (iogrid + siogrid)
 !        i = minloc(siogrid(2:ndatafmax),dim=1)  ! this is where zeros are again
@@ -614,7 +626,7 @@
         call spline_akima(x,piota,ai_aux_s,ai_aux_f,i,iflag)
         if(iflag < 0)                                                          &
      &       stop'piota: outside value from spline_akima requested'
-     
+
       CASE('cubic_spline') ! former ipiota=13
 ! cubic-spline   (iogrid + siogrid)
 !        i = minloc(siogrid(2:ndatafmax),dim=1)  ! this is where zeros are again
@@ -632,8 +644,8 @@
           endif
         endif
 
-      CASE('rational') ! 
-!  Ratio of polynomials. 
+      CASE('rational') !
+!  Ratio of polynomials.
 !  Numerator coefficients: ai(LBOUND) - ai(9)
 !  Denominator coefficients: ai(10) - ai(UBOUND)
          temp_num = zero
@@ -650,7 +662,7 @@
             piota = HUGE(piota)
          ENDIF
 
-      CASE('nice_quadratic') ! 
+      CASE('nice_quadratic') !
 !  Quadratic with slightly rearranged coefficients.
 !    iota(s) = a0(1-s) + a1 s + 4 a2 s (1 - s)
 !       a0 is the iota value at s = 0
@@ -664,17 +676,17 @@
 !  Linearly interpolated line segments to determine the iotabar profile.
          i = minloc(ai_aux_s(2:),dim=1)
          CALL line_seg(x,piota,ai_aux_s,ai_aux_f,i)
-            
+
       CASE default
 !  Power Series is the default
          DO i = UBOUND(ai,1), LBOUND(ai,1), -1
             piota = x*piota + ai(i)
          END DO
          IF (TRIM(piota_type_lc) .ne. 'power_series') THEN
-            WRITE(*,*) 'Unrecognized piota_type:', piota_type 
+            WRITE(*,*) 'Unrecognized piota_type:', piota_type
             WRITE(*,*) ' *** CHECK YOUR INPUT ***'
             WRITE(*,*) 'Changing piota_type from ''',                          &
-     &         TRIM(piota_type), '''to ''power_series''.' 
+     &         TRIM(piota_type), '''to ''power_series''.'
             piota_type = 'power_series'
          END IF
       END SELECT
@@ -683,7 +695,7 @@
 !     RFP/TOKAMAK: ai are coefficients of q_safety, NOT iota
          IF (piota .ne. zero) THEN
             piota = one / piota
-         ELSE 
+         ELSE
             piota = HUGE(piota)
          END IF
       END IF
@@ -744,7 +756,7 @@
       pmass_type_lc = pmass_type
       CALL tolower(pmass_type_lc)
       SELECT CASE(TRIM(pmass_type_lc))
-      
+
       CASE ('gauss_trunc')
 !  Truncated Gaussian
 !  p(s) = am(0) * (exp(-(s/am(1))**2) - exp(-(1/am(1))**2)
@@ -754,7 +766,7 @@
 !  c =  (1 - exp(-(1/am(1))**2)     ! so that p(0) = am(0).
          pmass = (am(0)/(one - exp(-(one / am(1)) ** 2))) *                    &
      &      (exp(-(x / am(1)) ** 2) - exp(-(one / am(1)) ** 2))
-     
+
       CASE ('two_power')
 !  Two power profile
 !  p(s) = [1 - s**am(0)]**am(1)          !! Old as of 2010-05-26
@@ -772,7 +784,7 @@
      &          (one-am(1))*(one/(one+(  x/am(5)**2)**am(6))**am(7)            &
      &                      -one/(one+(one/am(5)**2)**am(6))**am(7))/          &
      &                  (one-one/(one+(one/am(5)**2)**am(6))**am(7)))          &
-         
+
       CASE ('Akima_spline','akima_spline') ! former ipmass=11
 !        i = minloc(smagrid(2:ndatafmax),dim=1)  ! this is where zeros are again
         i = minloc(am_aux_s(2:),dim=1)  ! this is where zeros are again
@@ -820,7 +832,7 @@
      2  -TANH( 2*(am(i+2)-1._dp)  /am(i+3) ) )
 
       CASE('rational') !
-!  Ratio of polynomials. 
+!  Ratio of polynomials.
 !  Numerator coefficients: am(LBOUND) - am(9)
 !  Denominator coefficients: am(10) - am(UBOUND)
          temp_num = zero
@@ -841,20 +853,20 @@
 !  Linearly interpolated line segments to determine the pressure profile.
          i = minloc(am_aux_s(2:),dim=1)
          CALL line_seg(x,pmass,am_aux_s,am_aux_f,i)
-      
+
       CASE DEFAULT
          DO i = UBOUND(am,1), LBOUND(am,1), -1
             pmass = x*pmass + am(i)
          END DO
          IF (TRIM(pmass_type_lc) .ne. 'power_series') THEN
-            WRITE(*,*) 'Unrecognized pmass_type:', pmass_type 
+            WRITE(*,*) 'Unrecognized pmass_type:', pmass_type
             WRITE(*,*) ' *** CHECK YOUR INPUT ***'
             WRITE(*,*) 'Changing pmass_type from ''',                          &
-     &         TRIM(pmass_type), '''to ''power_series''.' 
+     &         TRIM(pmass_type), '''to ''power_series''.'
             pmass_type = 'power_series'
          END IF
       END SELECT
-   
+
       pmass = mu0*pres_scale*pmass
 
       END FUNCTION pmass

--- a/Testing/tests/free_boundary_test/CMakeLists.txt
+++ b/Testing/tests/free_boundary_test/CMakeLists.txt
@@ -101,7 +101,7 @@ set_tests_properties (vmec_free_boundary_check_bsupvmnc_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
 add_test (NAME    vmec_free_boundary_check_buco_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=4.3E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=buco -tol=5.8E-17)
 set_tests_properties (vmec_free_boundary_check_buco_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
@@ -121,7 +121,7 @@ set_tests_properties (vmec_free_boundary_check_chipf_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
 add_test (NAME    vmec_free_boundary_check_currumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=1.57E-6)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=currumnc -tol=2.4E-6)
 set_tests_properties (vmec_free_boundary_check_currumnc_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
@@ -191,7 +191,7 @@ set_tests_properties (vmec_free_boundary_check_iotaf_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
 add_test (NAME    vmec_free_boundary_check_jcuru_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=jcuru -tol=4.3E-7)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=jcuru -tol=4.5E-7)
 set_tests_properties (vmec_free_boundary_check_jcuru_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
@@ -201,7 +201,7 @@ set_tests_properties (vmec_free_boundary_check_jcurv_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")
 add_test (NAME    vmec_free_boundary_check_jdotb_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=jdotb -tol=1.5E-6)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_serial.vmec.nc -wout_file2=wout_test_parallel.vmec.nc -quantity=jdotb -tol=1.8E-6)
 set_tests_properties (vmec_free_boundary_check_jdotb_test
                       PROPERTIES
                       DEPENDS "vmec_free_boundary_serial_test;vmec_free_boundary_parallel_test")

--- a/Testing/tests/lasym_test/CMakeLists.txt
+++ b/Testing/tests/lasym_test/CMakeLists.txt
@@ -275,7 +275,7 @@ set_tests_properties (vmec_asym_check_vp_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_wb_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=wb -tol=5.0E-19)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=wb -tol=6.6E-19)
 set_tests_properties (vmec_asym_check_wb_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")

--- a/Testing/tests/lasym_test/CMakeLists.txt
+++ b/Testing/tests/lasym_test/CMakeLists.txt
@@ -105,7 +105,7 @@ set_tests_properties (vmec_asym_check_bvco_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_chi_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=6.3E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=9.4E-17)
 set_tests_properties (vmec_asym_check_chi_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")

--- a/Testing/tests/lasym_test/CMakeLists.txt
+++ b/Testing/tests/lasym_test/CMakeLists.txt
@@ -25,32 +25,32 @@ set_tests_properties (vmec_asym_check_aspect_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_b0_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=b0 -tol=2.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=b0 -tol=2.2E-15)
 set_tests_properties (vmec_asym_check_b0_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bdotb_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bdotb -tol=3.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bdotb -tol=4.6E-15)
 set_tests_properties (vmec_asym_check_bdotb_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bdotgradv_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bdotgradv -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bdotgradv -tol=2.1E-14)
 set_tests_properties (vmec_asym_check_bdotgradv_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_beta_vol_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=beta_vol -tol=8.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=beta_vol -tol=1.1E-15)
 set_tests_properties (vmec_asym_check_beta_vol_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_betapol_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betapol -tol=9.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betapol -tol=1.1E-13)
 set_tests_properties (vmec_asym_check_betapol_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_betator_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betator -tol=2.0E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betator -tol=2.5E-17)
 set_tests_properties (vmec_asym_check_betator_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -60,7 +60,7 @@ set_tests_properties (vmec_asym_check_betatotal_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_betaxis_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betaxis -tol=2.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=betaxis -tol=3.1E-16)
 set_tests_properties (vmec_asym_check_betaxis_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -70,12 +70,12 @@ set_tests_properties (vmec_asym_check_bmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bsubsmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsubsmns -tol=2.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsubsmns -tol=2.1E-15)
 set_tests_properties (vmec_asym_check_bsubsmns_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bsubumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsubumnc -tol=2.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsubumnc -tol=2.2E-15)
 set_tests_properties (vmec_asym_check_bsubumnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -85,7 +85,7 @@ set_tests_properties (vmec_asym_check_bsubvmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bsupumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsupumnc -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsupumnc -tol=2.1E-14)
 set_tests_properties (vmec_asym_check_bsupumnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -95,7 +95,7 @@ set_tests_properties (vmec_asym_check_bsupvmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_buco_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=buco -tol=4.0E-18)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=buco -tol=4.4E-18)
 set_tests_properties (vmec_asym_check_buco_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -105,12 +105,12 @@ set_tests_properties (vmec_asym_check_bvco_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_chi_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=4.2E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=4.5E-17)
 set_tests_properties (vmec_asym_check_chi_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_chipf_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chipf -tol=8.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chipf -tol=1.3E-15)
 set_tests_properties (vmec_asym_check_chipf_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -120,22 +120,22 @@ set_tests_properties (vmec_asym_check_currumnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_currvmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=currvmnc -tol=4.0E-8)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=currvmnc -tol=6.9E-8)
 set_tests_properties (vmec_asym_check_currvmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_DCurr_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DCurr -tol=5.0E-11)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DCurr -tol=5.1E-11)
 set_tests_properties (vmec_asym_check_DCurr_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_DGeod_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DGeod -tol=1.9E-11)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DGeod -tol=3.7E-11)
 set_tests_properties (vmec_asym_check_DGeod_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_DMerc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DMerc -tol=3.0E-11)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=DMerc -tol=3.7E-11)
 set_tests_properties (vmec_asym_check_DMerc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -170,7 +170,7 @@ set_tests_properties (vmec_asym_check_fsqz_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_gmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=gmnc -tol=3.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=gmnc -tol=4.7E-15)
 set_tests_properties (vmec_asym_check_gmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -180,7 +180,7 @@ set_tests_properties (vmec_asym_check_IonLarmor_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_iotaf_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=iotaf -tol=2.0E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=iotaf -tol=2.5E-14)
 set_tests_properties (vmec_asym_check_iotaf_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -190,7 +190,7 @@ set_tests_properties (vmec_asym_check_jcuru_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_jcurv_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=jcurv -tol=6.0E-11)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=jcurv -tol=7.7E-11)
 set_tests_properties (vmec_asym_check_jcurv_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -235,7 +235,7 @@ set_tests_properties (vmec_asym_check_presf_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_q_factor_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=q_factor -tol=2.0E-13)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=q_factor -tol=2.1E-13)
 set_tests_properties (vmec_asym_check_q_factor_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -250,12 +250,12 @@ set_tests_properties (vmec_asym_check_rbtor0_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_rmnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=rmnc -tol=3.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=rmnc -tol=7.3E-15)
 set_tests_properties (vmec_asym_check_rmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_specw_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=specw -tol=3.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=specw -tol=4.5E-16)
 set_tests_properties (vmec_asym_check_specw_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -280,7 +280,7 @@ set_tests_properties (vmec_asym_check_wb_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_wdot_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=wdot -tol=3.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=wdot -tol=4.5E-16)
 set_tests_properties (vmec_asym_check_wdot_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -310,7 +310,7 @@ set_tests_properties (vmec_asym_check_xn_nyq_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_zmns_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=zmns -tol=2.0E-15)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=zmns -tol=2.7E-15)
 set_tests_properties (vmec_asym_check_zmns_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")

--- a/Testing/tests/lasym_test/CMakeLists.txt
+++ b/Testing/tests/lasym_test/CMakeLists.txt
@@ -85,7 +85,7 @@ set_tests_properties (vmec_asym_check_bsubvmnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_bsupumnc_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsupumnc -tol=2.1E-14)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=bsupumnc -tol=3.7E-14)
 set_tests_properties (vmec_asym_check_bsupumnc_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -105,7 +105,7 @@ set_tests_properties (vmec_asym_check_bvco_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_chi_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=4.5E-17)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=chi -tol=6.3E-17)
 set_tests_properties (vmec_asym_check_chi_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
@@ -270,7 +270,7 @@ set_tests_properties (vmec_asym_check_volume_p_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")
 add_test (NAME    vmec_asym_check_vp_test
-          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=vp -tol=9.0E-16)
+          COMMAND $<TARGET_PROPERTY:xvmec,BINARY_DIR>/xwout_diff -wout_file1=wout_test_sym.vmec.nc -wout_file2=wout_test_asym.vmec.nc -quantity=vp -tol=1.5E-15)
 set_tests_properties (vmec_asym_check_vp_test
                       PROPERTIES
                       DEPENDS "vmec_sym_test;vmec_asym_test")


### PR DESCRIPTION
... are only parsed with single-precision
if specified without explicit double-precision suffix in the source code.

I found out (the hard way) that the constants used for Gauss-Legendre quadrature in profile_functions.f are only parsed with single-precision accuracy from the source file. This PR adds the _rprec suffixes to the constants in order to make Fortran aware of the available double-precision accuracy. This helps in comparisons with implementations in other languages.
Also, trailing whitespace is removed in this source code file in order to clean up future diffs. Sorry for the noise. The relevant changes are on lines 69 - 90.