### PR TITLE
Exact restart capability

### DIFF
--- a/.github/workflows/ci_doxygen.yaml
+++ b/.github/workflows/ci_doxygen.yaml
@@ -28,6 +28,8 @@ jobs:
                 sudo apt-get install libopenmpi-dev
                 sudo apt-get install libscalapack-openmpi-dev
                 sudo apt-get install doxygen
+                sudo apt-get install libblas-dev
+                sudo apt-get install liblapack-dev
             - name: Configure CMake
               shell: bash
               working-directory: ${{runner.workspace}}/Stellarator-Tools/build

--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -41,6 +41,8 @@ jobs:
                 sudo apt-get install libnetcdff-dev
                 sudo apt-get install libopenmpi-dev
                 sudo apt-get install libscalapack-openmpi-dev
+                sudo apt-get install libblas-dev
+                sudo apt-get install liblapack-dev
             - name: Configure CMake Mac
               if: ${{matrix.os == 'macos-latest'}}
               shell: bash

--- a/.github/workflows/ci_test_master.yaml
+++ b/.github/workflows/ci_test_master.yaml
@@ -41,6 +41,8 @@ jobs:
                 sudo apt-get install libnetcdff-dev
                 sudo apt-get install libopenmpi-dev
                 sudo apt-get install libscalapack-openmpi-dev
+                sudo apt-get install libblas-dev
+                sudo apt-get install liblapack-dev
             - name: Configure CMake Mac
               if: ${{matrix.os == 'macos-latest'}}
               shell: bash

--- a/Sources/Input_Output/CMakeLists.txt
+++ b/Sources/Input_Output/CMakeLists.txt
@@ -22,4 +22,5 @@ target_sources(vmec
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vmercier.f>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/write_dcon.f>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/wrout.f>
+               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/restart.f>
 )


### PR DESCRIPTION
This add nearly a binary identical restart capability to VMEC by saving the xc array to new netcdf file. Currently the results are not identical for compared to a full run. But restarts always end at the same place each time.