### PR TITLE
Fix profile1d reset

### DIFF
--- a/Sources/General/funct3d.f
+++ b/Sources/General/funct3d.f
@@ -179,8 +179,8 @@ C-----------------------------------------------
 !     EITHER PHIEDGE OR THE INITIAL CROSS SECTION ACCORDING
 !     TO THE SCALING LAW  R*BTOR .EQ. PHIEDGE/(R1 * Z1).
 
-      IF (lfreeb       .AND.
-     &    iter2 .GT. 1 .AND.
+      IF (lfreeb                          .AND.
+     &    (iter2 .GT. 1 .or. ivac .ge. 0) .AND.
      &    iequi .EQ. 0) THEN
 
          IF (ictrl_prec2d.LE.1 .AND. (fsqr + fsqz).LE.1.e-3_dp) 
@@ -598,7 +598,9 @@ C-----------------------------------------------
 !     EITHER PHIEDGE OR THE INITIAL CROSS SECTION ACCORDING
 !     TO THE SCALING LAW  R*BTOR .EQ. PHIEDGE/(R1 * Z1).
 
-      IF (lfreeb .and. iter2.gt.1 .and. iequi.eq.0) THEN
+      IF (lfreeb                          .and.
+     &    (iter2 .gt. 1 .or. ivac .ge. 0) .and.
+     &    iequi .eq. 0) THEN
          IF (ictrl_prec2d  .le. 1 .and.
      &       (fsqr + fsqz) .le. 1.e-3_dp) THEN
             ivac = ivac+1   !decreased from e-1 to e-3 - sph12/04

--- a/Sources/General/vmec_params.f
+++ b/Sources/General/vmec_params.f
@@ -10,26 +10,26 @@ C-----------------------------------------------
 
       INTEGER, PRIVATE :: ink
       INTEGER, PARAMETER, DIMENSION(0:mpold) ::
-     1  jmin1 = (/ 1,1,(2,ink=2,mpold) /),        !starting js(m) values where R,Z are non-zero
-     2  jmin2 = (/ 1,2,(2,ink=2,mpold) /),        !starting js(m) values for which R,Z are evolved
-     3  jlam  = (/ 2,2,(2,ink=2,mpold) /)         !starting js(m) values for which Lambda is evolved
+     &  jmin1 = (/ 1,1,(2,ink=2,mpold) /),        !starting js(m) values where R,Z are non-zero
+     &  jmin2 = (/ 1,2,(2,ink=2,mpold) /),        !starting js(m) values for which R,Z are evolved
+     &  jlam  = (/ 2,2,(2,ink=2,mpold) /)         !starting js(m) values for which Lambda is evolved
 
 !  Besure to update werror in fileout.f when adding more error flags.
       INTEGER, PARAMETER :: norm_term_flag=0, bad_jacobian_flag=1, 
-     1                      more_iter_flag=2, 
-     2                      jac75_flag=4, input_error_flag=5,
-     3                      phiedge_error_flag=7,
-     4                      ns_error_flag=8,
-     5                      misc_error_flag=9,
-     6                      successful_term_flag=11, !ftol force criterion has been met
-     7                      bsub_bad_js1_flag=12,
-     8                      r01_bad_value_flag=13,
-     9                      arz_bad_value_flag=14
+     &                      more_iter_flag=2,
+     &                      jac75_flag=4, input_error_flag=5,
+     &                      phiedge_error_flag=7,
+     &                      ns_error_flag=8,
+     &                      misc_error_flag=9,
+     &                      successful_term_flag=11, !ftol force criterion has been met
+     &                      bsub_bad_js1_flag=12,
+     &                      r01_bad_value_flag=13,
+     &                      arz_bad_value_flag=14
       INTEGER, PARAMETER :: restart_flag=1, readin_flag=2,
-     1                      timestep_flag=4,output_flag=8, 
-     2                      cleanup_flag=16, reset_jacdt_flag=32
-    
-      REAL(rprec), PARAMETER :: pdamp = 0.05_dp  
+     &                      timestep_flag=4,output_flag=8,
+     &                      cleanup_flag=16, reset_jacdt_flag=32
+
+      REAL(rprec), PARAMETER :: pdamp = 0.05_dp
       CHARACTER(LEN=*), PARAMETER :: version_ = '10.0'
 !-----------------------------------------------
 !   L o c a l   V a r i a b l e s

--- a/Sources/NESTOR_vacuum/analyt.f
+++ b/Sources/NESTOR_vacuum/analyt.f
@@ -233,7 +233,7 @@
 !>  @param[out] tlp
 !>  @param[out] tlm
 !-------------------------------------------------------------------------------
-      SUBROUTINE initialize(adp, adm, cma, sqrtc, sqrta, tlp, tlm)
+      PURE SUBROUTINE initialize(adp, adm, cma, sqrtc, sqrta, tlp, tlm)
       USE parallel_include_module
       USE vacmod0, ONLY: mf, nf
 
@@ -368,7 +368,7 @@
 !>  @param[in]    t0    Inital
 !>  @param[inout] tl    Final recurrence.
 !-------------------------------------------------------------------------------
-      SUBROUTINE recurrence_sum(a, b, sqrtc, sqrta, cma, t0, tl)
+      PURE SUBROUTINE recurrence_sum(a, b, sqrtc, sqrta, cma, t0, tl)
       USE stel_kinds
       USE vacmod0, ONLY: mf, nf
 

--- a/Sources/TimeStep/runvmec.f
+++ b/Sources/TimeStep/runvmec.f
@@ -147,12 +147,41 @@ C-----------------------------------------------
      &                     RUNVMEC_COMM_WORLD, MPI_ERR)
             CALL MPI_Bcast(lamscale, 1, MPI_REAL8, 0,
      &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+#if 0
+            CALL MPI_Bcast(am, SIZE(am), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(am_aux_s, SIZE(am_aux_s), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(am_aux_f, SIZE(am_aux_f), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ac, SIZE(ac), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ac_aux_s, SIZE(ac_aux_s), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ac_aux_f, SIZE(ac_aux_f), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ai, SIZE(ai), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ai_aux_s, SIZE(ai_aux_s), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(ai_aux_f, SIZE(ai_aux_f), MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(curtor, 1, MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(currv, 1, MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(pres_scale, 1, MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(bloat, 1, MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+            CALL MPI_Bcast(phiedge, 1, MPI_REAL8, 0,
+     &                     RUNVMEC_COMM_WORLD, MPI_ERR)
+#endif
             js = SIZE(rmn_bdy, 1)*SIZE(rmn_bdy, 2)*SIZE(rmn_bdy, 3)
             CALL MPI_Bcast(rmn_bdy, js, MPI_REAL8, 0,                          &
      &                     RUNVMEC_COMM_WORLD, MPI_ERR)
             CALL MPI_Bcast(zmn_bdy, js, MPI_REAL8, 0,                          &
      &                     RUNVMEC_COMM_WORLD, MPI_ERR)
-
             nsmin = t1lglob; nsmax = t1rglob
             DO js = nsmin, nsmax
                pphip(:,js) = phips(js)
@@ -319,17 +348,9 @@ C-----------------------------------------------
 
          grid_size(grid_id) = nsval
          grid_procs(grid_id) = nranks
-         
-!  JDH 2012-06-20. V3FIT fix, inserted with change from VMEC 8.48 -> 8.49
-!  (Not sure just what in initialize_radial messes up convergence - happens slowly)
-!  Logical l_v3fit is declared in vmec_input, available via vmec_main
-         IF (l_v3fit .AND. ns_old .ne. nsval) THEN
-            CALL initialize_radial(nsval, ns_old, delt0r, lscreen,
-     &                             reset_file_name)
-         ELSE IF (ns_old .le. nsval) THEN
-            CALL initialize_radial(nsval, ns_old, delt0r, lscreen,
-     &                             reset_file_name)
-         END IF
+
+         CALL initialize_radial(nsval, ns_old, delt0r, lscreen,
+     &                          reset_file_name)
 
          CALL Initialize_bst(.FALSE., nsval, blklength)
 


### PR DESCRIPTION
Fix an issue where the inital multi_grid_equilibrium and multi_grid_v3post would have the wrong initial condition on the child processes. This is not an issue in normal reconstruction because they would used the default from the namelist as the inital parameter values. Fix by John Schmitt.