### PR TITLE
Size the T_l recurrence passes of the analytic add-back by their growth rate

### DIFF
--- a/Sources/NESTOR_vacuum/analyt.f
+++ b/Sources/NESTOR_vacuum/analyt.f
@@ -284,17 +284,17 @@
 !-------------------------------------------------------------------------------
 !>  @brief Querey if to use forward or backwards propagation.
 !>
-!>  Only switch to backward when the forward spurious-mode growth
-!>  (|r1 r2| = B/A) would actually exceed double precision over kL steps.
-!>  Threshold: forward is considered stable as long as (B/A)^kL < 1e10,
-!>  i.e. spurious amplitude stays within ~1e10 of the particular solution.
-!>  Near-degenerate kl (|r1|~|r2|~1) fall in the forward branch, where
-!>  zero-seed Miller is known to misconverge (spurious modes never damp).
-!>  Formula: kL * ln(B/A) < ln(1e10) -> B/A < exp(ln(1e10)/kL).
+!>  The homogeneous solutions of the recurrence are a complex pair of
+!>  modulus sqrt(a/b), so a forward pass over the mf + nf steps
+!>  amplifies the rounding of its inputs by sqrt(a/b)^(mf + nf). The
+!>  forward pass is used while that growth stays below ten, otherwise
+!>  the recurrence is run backward from a seed placed far enough above
+!>  mf + nf.
+!>  Formula: (mf + nf) * ln(a/b) <= 2 ln(10).
 !>
 !>  @param[in] a
 !>  @param[in] b
-!>  @returns true if log(a/b) > ln(1E10)
+!>  @returns true if (mf + nf) * log(a/b) > 2 ln(10)
 !-------------------------------------------------------------------------------
       PURE FUNCTION useBackward(a, b)
       USE stel_kinds
@@ -308,12 +308,13 @@
       REAL(dp), INTENT(in) :: b
 
 !  local parameters
-      REAL(dp), PARAMETER  :: kLogGrowthThreshold = 23.0258509299 ! ln(1e10)
+      REAL(dp), PARAMETER  :: kMaxForwardLogGrowth =
+     &   2.302585092994046_dp
 
 !  Start of executable code
       useBackward = a .gt. b   .and.
      &              b .gt. 0.0 .and.
-     &              (mf + nf)*log(a/b) .gt. kLogGrowthThreshold
+     &              (mf + nf)*log(a/b) .gt. 2.0_dp*kMaxForwardLogGrowth
 
       END FUNCTION
 
@@ -387,23 +388,27 @@
       REAL(dp)                                       :: high
       REAL(dp)                                       :: current
       REAL(dp)                                       :: low
-      REAL(dp)                                       :: scale
       REAL(dp)                                       :: sign1
       INTEGER                                        :: l
+      INTEGER                                        :: ntail
 
 !  local parameters
-      INTEGER, PARAMETER :: kTailExtra = 50
+!  The zero seed of a backward pass contaminates tl(l) by
+!  (b/a)^((top - l)/2) of tl(top). The pass starts ntail steps above
+!  mf + nf so that this falls below 1e-17 at mf + nf.
+      REAL(dp), PARAMETER :: kMinSeedLogDecay = 39.14394658089878_dp
 
 !  Start of executable code
       IF (useBackward(a,b)) THEN
+         ntail = CEILING(2.0_dp*kMinSeedLogDecay/LOG(a/b))
          high = 0.0
-         current = 1.0E-300_dp
-         IF (MOD(mf + nf + kTailExtra, 2) .eq. 0) THEN
+         current = 0.0
+         IF (MOD(mf + nf + ntail, 2) .eq. 0) THEN
             sign1 = -1
          ELSE
             sign1 = 1
          ENDIF
-         DO l = mf + nf + kTailExtra, mf + nf + 2, -1
+         DO l = mf + nf + ntail, mf + nf + 2, -1
             low = recurrence(b, a, sqrtc, sqrta, sign1,
      &                       l + 1, l, 2*l + 1, cma, high, current)
             high = current
@@ -417,10 +422,7 @@
             current = tl(l - 1)
             sign1 = -sign1
          END DO
-         scale = t0/tl(0)
-         DO l = 0, mf + nf
-            tl(l) = tl(l)*scale
-         END DO
+         tl(0) = t0
       ELSE
          sign1 = 1
          DO l = 0, mf + nf - 1


### PR DESCRIPTION
The homogeneous solutions of the T_l recurrence in `analyt.f` are a complex pair of modulus sqrt(a/b), so the backward pass damped its seed by (b/a)^25 over its fixed tail of 50 steps rather than (b/a)^50, and the forward pass was kept up to a growth of (a/b)^(kL/2) = 1e5 over the kL = mf + nf steps. The tail now starts far enough above mf + nf that the seed has decayed below 1e-17 there, the forward pass is used only while its growth stays below ten, and the normalization of the backward pass to t0 is dropped since the recurrence is inhomogeneous. This mirrors https://github.com/proximafusion/vmecpp/pull/836.

Residual of the first vacuum solve on an exact exterior problem, a line of dipoles on the magnetic axis inside the cth-like boundary whose total field on the surface is zero, as the rms of `bsqvac` relative to the external magnetic pressure (ns = 15, nzeta = 60):

| mpol, ntor | before | after |
| --- | --- | --- |
| 5, 4 | 9.1e-2 | 9.1e-2 |
| 8, 8 | 2.2e-2 | 2.2e-2 |
| 12, 12 | 2.5e-3 | 2.5e-3 |
| 16, 12 | 2.3e-4 | 2.3e-4 |
| 16, 16 | 6.5e-1 | 2.3e-4 |

The same test on a helical torus at mpol = 8, ntor = 4 gives 7.1e-6 with lasym = F and 4.0e-5 with lasym = T, unchanged from before. The vmec ctests pass.
