### PR TITLE
Carry the Jacobian sign in chi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,15 @@ add_library (vmec)
 #  so that |B| rather than the total pressure is continuous there.
 OPTION (USE_EXT_PRESSURE "Use external pressure" ON)
 
+#  Write the poloidal flux chi without the Jacobian sign, as VMEC 8.52 does.
+OPTION (USE_UNSIGNED_CHI "Use unsigned chi" ON)
+
 target_compile_definitions (vmec
 
                             PUBLIC
 
                             $<$<BOOL:${USE_EXT_PRESSURE}>:EXT_PRESSURE>
+                            $<$<BOOL:${USE_UNSIGNED_CHI}>:UNSIGNED_CHI>
 )
 
 target_link_libraries (vmec PUBLIC stell)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,11 @@ add_library (vmec)
 #  so that |B| rather than the total pressure is continuous there.
 OPTION (USE_EXT_PRESSURE "Use external pressure" ON)
 
-#  Write the poloidal flux chi without the Jacobian sign, as VMEC 8.52 does.
-OPTION (USE_UNSIGNED_CHI "Use unsigned chi" ON)
-
 target_compile_definitions (vmec
 
                             PUBLIC
 
                             $<$<BOOL:${USE_EXT_PRESSURE}>:EXT_PRESSURE>
-                            $<$<BOOL:${USE_UNSIGNED_CHI}>:UNSIGNED_CHI>
 )
 
 target_link_libraries (vmec PUBLIC stell)

--- a/Sources/General/vmec_params.f
+++ b/Sources/General/vmec_params.f
@@ -30,7 +30,7 @@ C-----------------------------------------------
      &                      cleanup_flag=16, reset_jacdt_flag=32
 
       REAL(rprec), PARAMETER :: pdamp = 0.05_dp
-      CHARACTER(LEN=*), PARAMETER :: version_ = '10.0'
+      CHARACTER(LEN=*), PARAMETER :: version_ = '10.1'
 !-----------------------------------------------
 !   L o c a l   V a r i a b l e s
 !-----------------------------------------------

--- a/Sources/Input_Output/eqfor.f
+++ b/Sources/Input_Output/eqfor.f
@@ -180,7 +180,11 @@ C-----------------------------------------------
          chi1(i) = chi1(i - 1) + hs*(phip(i)*iotas(i))
       END DO
 
+#ifdef UNSIGNED_CHI
       chi = twopi*chi1
+#else
+      chi = twopi*signgs*chi1
+#endif
 
 !	WRITE (36, 201) (i, phi1(i), chi1(i), iotas(i), i=1, ns)
 !201   FORMAT (i4, 1p,3e14.6)

--- a/Sources/Input_Output/eqfor.f
+++ b/Sources/Input_Output/eqfor.f
@@ -180,11 +180,7 @@ C-----------------------------------------------
          chi1(i) = chi1(i - 1) + hs*(phip(i)*iotas(i))
       END DO
 
-#ifdef UNSIGNED_CHI
-      chi = twopi*chi1
-#else
       chi = twopi*signgs*chi1
-#endif
 
 !	WRITE (36, 201) (i, phi1(i), chi1(i), iotas(i), i=1, ns)
 !201   FORMAT (i4, 1p,3e14.6)


### PR DESCRIPTION
**Change** - `eqfor.f` accumulates `chi` as `twopi*signgs*chi1`, and `vmec_params.f` bumps `version_` from '10.0' to '10.1' so a reader can tell which convention a wout holds.

**Cause** - every other flux quantity in the same wout carries the Jacobian sign and `chi` does not: `fileout.f:211` writes `phi = (signgs*twopi*hs)*phi`, `wrout.f:1299` and `1301` write `phipf` and `chipf` as `twopi*signgs*...`, and `eqfor.f:220` forms the threed1 poloidal flux with `fac = twopi*signgs`. With the usual negative Jacobian the file therefore holds `chi = -integral(iota dphi)`, so `dchi/dphi` read back from it has the opposite sign to `iotaf` beside it, and `chi` has the opposite sign to the integral of the `chipf` stored next to it.

**Evidence** - on a cth-like fixed-boundary case at ns = 25 with `signgs = -1`, the median of `(dchi/dphi) / iotas` over the half grid goes from -1.000000 to +1.000000, and `chi(ns)` from +4.007483e-02 to -4.007483e-02, against an integral of the file's own `chipf` of -4.006393e-02. On `solovev` the same median goes from -1.000000 to +1.000000. Only the sign moves; the magnitude is unchanged. The written file reports `version_ = 10.1`, which `read_wout_mod.f90` already parses as a real and branches on for earlier format changes.

**Scope** - `chi` is written to the wout and to the threed1 file and is read by neither the force balance nor any other quantity, so no equilibrium changes.

The same change is proposed for VMEC++ in https://github.com/proximafusion/vmecpp/pull/772.
